### PR TITLE
Output trace is an output

### DIFF
--- a/src/metaprob/infer.clj
+++ b/src/metaprob/infer.clj
@@ -36,7 +36,7 @@
 (define make-env
   (gen [parent]
     (assert (environment? parent) parent)
-    (mutable-trace "*parent*" (** (trace :value parent)))))
+    (mutable-trace "*parent*" parent)))
 
 (define env-lookup
   (gen [env name]
@@ -300,7 +300,7 @@
                                    output?))
                [result
                 (if output?
-                  (trace-set output result-key suboutput)
+                  (trace-set-subtrace output result-key suboutput)
                   output)
                 (+ subscore score)])
 

--- a/src/metaprob/infer.clj
+++ b/src/metaprob/infer.clj
@@ -396,8 +396,6 @@
                        (+ score subscore)))
           [(reverse values) output score])))
     (luup 0 (list) (trace) 0)))
->>>>>>> tests run with new eval protocol
-
 
 ;; -----------------------------------------------------------------------------
 

--- a/src/metaprob/infer.clj
+++ b/src/metaprob/infer.clj
@@ -36,7 +36,7 @@
 (define make-env
   (gen [parent]
     (assert (environment? parent) parent)
-    (mutable-trace "*parent*" (trace :value parent))))
+    (mutable-trace "*parent*" (** (trace :value parent)))))
 
 (define env-lookup
   (gen [env name]
@@ -83,7 +83,7 @@
                        ;; The pattern [& x] matches anything
                        (and (eq i (sub count 2))
                             (eq (trace-get pattern i) "&"))
-                       (match-bind! (trace-subtrace pattern (add i 1))
+                       (match-bind! (trace-subtrace pattern (+ i 1))
                                     cursor
                                     env)
 
@@ -101,7 +101,8 @@
                        ;; Bind pattern to input, and continue
                        true
                        (block (match-bind! (trace-subtrace pattern i) (first cursor) env)
-                              (loup (add i 1) (rest cursor))))))
+                              (loup (+ i 1) (rest cursor))))))
+
              (loup 0 (to-list input)))
       (do (pprint pattern)
           (assert false ["bad pattern" pattern input])))
@@ -141,50 +142,73 @@
     (assert (ok-key? key) key)
     key))
 
-;; Extend an address.
+(define maybe-subtrace
+  (gen [tr adr]
+    (if (trace-has-subtrace? tr adr)
+      (trace-subtrace tr adr)
+      (trace))))
 
-(define extend-addr
-  (gen [adr key]
-    (add adr (addr key))))
+(define maybe-set-subtrace
+  (gen [output key suboutput]
+    (assert (trace? output) "output")
+    (assert (trace? suboutput) "suboutput")
+    (if (empty-trace? suboutput)
+      output
+      (trace-set-subtrace output key suboutput))))
 
 ;; ----------------------------------------------------------------------------
 
-(declare infer-apply-native infer-eval)
+(declare infer-apply-native infer-apply-neuf infer-eval infer-eval-sequence)
 
-;; Useful invariant: if output is non-nil, then on returning [value score],
-;; we have value = (trace-ref output).
+;; Main entry point: an `apply` that respects interventions
+;; and constraints, records choices made, and computes scores.
 
-;; Main entry point: a version of `apply` that respects interventions
-;; and constraints, records choices, and computes scores.
+;; Backward compatible version
 
 (define infer-apply
-  (gen [proc inputs intervene target output]
+  (gen [proc inputs intervene target output-place]
+    (define [val output score]
+      (infer-apply-neuf proc inputs
+                        (or intervene (trace))
+                        (or target (trace))
+                        (if output-place true false)))
+    (if output-place
+      (trace-update! output-place output))
+    [val score]))
+
+;; Output-not-an-input version
+
+(define infer-apply-neuf
+  (gen [proc inputs intervene target output?]
     (assert (or (list? inputs) (tuple? inputs))
             ["inputs neither list nor tuple" inputs])
-    (assert (or (eq output nil)
-                (mutable-trace? output))
-            output)
+    (assert (trace? intervene) ["intervene" intervene])
+    (assert (trace? target) ["target" target])
+    (assert (boolean? output?) output?)
     (if (and (trace? proc) (trace-has? proc "infer-method"))
       ;; Proc is a special inference procedure returned by `inf`.
       ;; Return the value+score that the infer-method computes.
-      ((trace-get proc "infer-method") inputs intervene target output)
+      ((trace-get proc "infer-method") inputs intervene target output?)
       (if (and (foreign-procedure? proc)
-               (not (or intervene target output)))
-        [(generate-foreign proc inputs) 0]
+               (empty-trace? intervene)
+               (empty-trace? target)
+               (not output?))
+        ;; Bypass interpreter when there is no need to use it.
+        [(generate-foreign proc inputs) (trace) 0]
         (block
          ;; Proc is a generative procedure, either 'foreign' (opaque, compiled)
          ;; or 'native' (interpreted).
          ;; First call the procedure.  We can't skip the call when there
          ;; is an intervention, because the call might have side effects.
-         (define [value score]
+         (define [value output score]
            (if (and (trace? proc)
                     (trace-has? proc "generative-source")
                     (trace-has? proc "environment"))
              ;; 'Native' generative procedure
-             (infer-apply-native proc inputs intervene target output)
+             (infer-apply-native proc inputs intervene target output?)
              (if (foreign-procedure? proc)
                ;; 'Foreign' generative procedure
-               [(generate-foreign proc inputs) 0]
+               [(generate-foreign proc inputs) (trace) 0]
                (block (pprint proc)
                       (error "infer-apply: not a procedure" proc)))))
          ;; Apply intervention trace to get modified value
@@ -208,10 +232,12 @@
                       negative-infinity))
                 score)]
              [post-intervention-value score]))
-         ;; Store value in output trace
-         (if output
-           (trace-set! output post-target-value))
-         [post-target-value score2])))))
+         (assert (trace? output) ["lose" output? output])
+         [post-target-value
+          (if output?
+            (trace-set output post-target-value)
+            output)
+          score2])))))
 
 ;; Invoke a 'native' generative procedure, i.e. one written in
 ;; metaprob, with inference mechanics (traces and scores).
@@ -221,7 +247,7 @@
         inputs
         intervene
         target
-        output]
+        output?]
     (define source (trace-subtrace proc "generative-source"))
     (define environment (trace-get proc "environment"))
     (define new-env (make-env environment))
@@ -233,126 +259,184 @@
                 new-env
                 intervene
                 target
-                output)))
+                output?)))
 
 ;; Evaluate the body of a 'native' procedure by recursive descent.
 
 (define infer-eval
-  (gen [exp env intervene target output]
-    (assert (or (eq output nil)
-                (mutable-trace? output))
-            output)
-    (define walk
-      (gen [exp env address]
-        (assert (trace? exp) ["bad trace - eval" exp address])
-        ;; (print ["eval" (trace-get exp) address])
-        ;; (pprint exp)
-        (define [v score]
-          ;; Dispatch on type of expression
-          (case (trace-get exp)
+  (gen [exp env intervene target output?]
+    (assert (trace? exp) ["bad expression - eval" exp])
+    (assert (environment? env) ["bad env - eval" env])
+    (assert (trace? intervene) ["bad intervene" intervene])
+    (assert (trace? target) ["bad target" target])
+    (assert (boolean? output?) output?)
+    (define output-set
+      (gen [output key suboutput]
+        (if output?
+          (maybe-set-subtrace output key suboutput)
+          output)))
+    (define [v output score]
+      ;; Dispatch on type of expression
+      (case (trace-get exp)
 
-            ;; Application of a procedure to arguments (call)
-            "application"
-            (block (define subscore (empty-trace 0))
-                   ;; Evaluate all subexpressions, including the procedure
-                   ;; position
-                   (define values
-                     (map (gen [i]
-                            (define [v s]
-                              (walk (trace-subtrace exp i)
-                                    env
-                                    (extend-addr address i)))
-                            (trace-set! subscore (add (trace-get subscore) s))
-                            v)
-                          (range (trace-count exp))))
-                   (define new-addr
-                     (extend-addr address
-                                  (application-result-key (trace-subtrace exp 0))))
-                   (define [val score]
-                     (infer-apply (first values)
-                                  (rest values)
-                                  (maybe-subtrace intervene new-addr)
-                                  (maybe-subtrace target new-addr)
-                                  (lookup output new-addr)))
-                   [val (add (trace-get subscore) score)])
+        ;; Application of a procedure to arguments (call)
+        "application"
+        (block (define [values output score]
+                 (infer-eval-sequence exp env intervene target output?))
 
-            "variable"
-            [(env-lookup env (trace-get exp "name")) 0]
+               (define result-key
+                 (application-result-key (trace-subtrace exp 0)))
 
-            "literal"
-            [(trace-get exp "value") 0]
+               (define [result suboutput subscore]
+                 (infer-apply-neuf (first values)
+                                   (rest values)
+                                   (maybe-subtrace intervene result-key)
+                                   (maybe-subtrace target result-key)
+                                   output?))
+               [result
+                (output-set output result-key suboutput)
+                (+ subscore score)])
 
-            ;; Gen-expression yields a generative procedure
-            "gen"
-            [(mutable-trace :value "prob prog"
-                            "name" (trace-name exp)
-                            "generative-source" (** exp)
-                            "environment" (trace :value env))
-             0]
+        "variable"
+        [(env-lookup env (trace-get exp "name")) (trace) 0]
 
-            ;; Conditional
-            "if"
-            (block
-             (define [pred pred-score]
-               (walk (trace-subtrace exp "predicate") env
-                     (extend-addr address "predicate")))
-             (if pred
-               (block (define [val score]
-                        (walk (trace-subtrace exp "then") env
-                              (extend-addr address "then")))
-                      [val (add pred-score score)])
-               (block (define [val score]
-                        (walk (trace-subtrace exp "else") env
-                              (extend-addr address "else")))
-                      [val (add pred-score score)])))
+        "literal"
+        [(trace-get exp "value") (trace) 0]
 
-            ;; Sequence of expressions and definitions
-            "block"
-            (block (define new-env (make-env env))
-                   (define subscore (empty-trace 0))
-                   (define values
-                     ;; This assumes that map is left to right!
-                     (map (gen [i]
-                            (define [v s]
-                              (walk (trace-subtrace exp i) new-env
-                                    (extend-addr address i)))
-                            (trace-set! subscore
-                                        (add (trace-get subscore) s))
-                            v)
-                          (range (trace-count exp))))
-                   (if (gt (length values) 0)
-                     [(last values) (trace-get subscore)]
-                     [(empty-trace) (trace-get subscore)]))
+        ;; Gen-expression yields a generative procedure
+        "gen"
+        [(mutable-trace :value "prob prog"
+                        "name" (trace-name exp)
+                        "generative-source" (** exp)
+                        "environment" env)
+         (trace)
+         0]
 
-            ;; Definition: bind a variable to some value
-            "definition"
-            (block (define key
-                     (name-for-definiens
-                      (trace-subtrace exp "pattern")))
-                   ;; (print ["definiens =" key])
-                   (define [val score]
-                     (walk (trace-subtrace exp key) env
-                           (extend-addr address key)))
-                   [(match-bind! (trace-subtrace exp "pattern")
-                                 val
-                                 env)
-                    score])
+        ;; Conditional
+        "if"
+        (block
+         (define [pred-val pred-output pred-score]
+           (infer-eval (trace-subtrace exp "predicate")
+                       env intervene target output?))
+         (define key
+           (if pred-val "then" "else"))
+         (define [val output score]
+           (infer-eval (trace-subtrace exp key) env intervene target output?))
 
-            (block (pprint exp)
-                   (error "Not a code expression"))))
-        (if (and intervene (trace-has? intervene address))
-          [(trace-get intervene address) score]
-          [v score])))
-    (walk exp env (addr))))
+         [val
+          (output-set (output-set (trace) "predicate" pred-output)
+                      key
+                      output)
+          (+ pred-score score)])
 
-(define inf
+        ;; Sequence of expressions and definitions
+        "block"
+        (block (define [values output score]
+                 (infer-eval-sequence exp (make-env env) intervene target output?))
+
+               [(last values) output score])
+
+        ;; Definition: bind a variable to some value
+        "definition"
+        (block (define key
+                 (name-for-definiens
+                  (trace-subtrace exp "pattern")))
+               ;; (print ["definiens =" key])
+               (define [val output score]
+                 (infer-eval (trace-subtrace exp key) env intervene target output?))
+               [(match-bind! (trace-subtrace exp "pattern")
+                             val
+                             env)
+                (output-set (trace) key output)
+                score])
+
+        (block (pprint exp)
+               (error "Not a code expression"))))
+
+    (assert (trace? output) output)
+
+    (define v (if (trace-has? intervene)
+                (trace-get intervene)
+                v))
+
+    [v
+     (if (and output? (not (empty-trace? output)))
+       (trace-set output v)
+       output)
+     score]))
+
+(define z (gen [n v]
+  (assert (tuple? v) ["tuple" v])
+  (assert (= (length v) n) ["tuple length" n v])
+  v))
+
+(define infer-eval-sequence
+  (gen [exp env intervene target output?]
+    (assert (trace? exp) exp)
+    (assert (gte (trace-count exp) 1) exp)
+
+    (define luup
+      (gen [i values output score]
+        (if (trace-has? exp i)
+          (block (define [val suboutput subscore]
+                   (infer-eval (trace-subtrace exp i)
+                               env
+                               (maybe-subtrace intervene i)
+                               (maybe-subtrace target i)
+                               output?))
+                 (luup (+ i 1)
+                       (pair val values)
+                       (if output?
+                         (maybe-set-subtrace output i suboutput)
+                         output)
+                       (+ score subscore)))
+          [(reverse values) output score])))
+    (luup 0 (list) (trace) 0)))
+>>>>>>> tests run with new eval protocol
+
+
+;; -----------------------------------------------------------------------------
+
+(define inf-neuf
   (gen [name infer-method]
+    (assert (procedure? infer-method) infer-method)
     (trace-as-procedure (mutable-trace "name" (add "inf-" (procedure-name infer-method))
-                                       "infer-method" (trace :value infer-method))
+                                       "infer-method" infer-method)
                         ;; When called from Clojure:
                         (gen [& inputs]
-                          (nth (infer-method inputs nil nil nil)
+                          (nth (infer-method inputs (trace) (trace) false)
                                0)))))
+
+(define inf
+  (gen [name infer-method-classic]
+    (assert (procedure? infer-method-classic) infer-method-classic)
+    (inf-neuf name
+              ;; 2nd arg to inf-neuf is new-style infer method, which is a 
+              ;;  deterministic procedure
+              (gen [inputs intervene target output?]
+                (define output (mutable-trace))
+                (define [value score]
+                  ;; Call old-style infer method using old protocol
+                  (infer-method-classic inputs
+                                        (if (empty-trace? intervene)
+                                          nil
+                                          intervene)
+                                        (if (empty-trace? target)
+                                          nil
+                                          target)
+                                        (if output?
+                                          output
+                                          nil)))
+                [value output score]))))
+
+;; Experimental
+
+(define opaque
+  (gen [name proc]
+    (inf name
+         (gen [inputs intervene target output]
+           ;; Ignore the traces.
+           (infer-apply proc inputs nil nil nil)))))
 
 (define apply
   (trace-as-procedure
@@ -365,44 +449,37 @@
 
 ;; map defined using inf (instead of with-address)
 
-(define map-issue-20
-  (inf "map"
-       (gen [[fun sequ] intervene target output]
-         (block (define re
-                  (gen [l i]
-                    (if (pair? l)
-                      (block (define out (if output (lookup output i) nil))
-                             (define [valu subscore]
-                               (infer-apply fun
-                                            [(first l)]
-                                            ;; advance traces by address i
-                                            (maybe-subtrace intervene i)
-                                            (maybe-subtrace target i)
-                                            out))
-                             (if output
-                               (trace-set! output i out))
-                             (define [more-valu more-score]
-                               (re (rest l) (add i 1)))
-                             [(pair valu more-valu)
-                              (add subscore more-score)])
-                      [l 0])))
-                (if (tuple? sequ)
-                  (to-tuple (re (to-list sequ) 0))
-                  (re sequ 0))))))
+(define map
+  (inf-neuf "map"
+            (gen [[fun sequ] intervene target output?]
+              (block (define re
+                       (gen [i l]
+                         (if (pair? l)
+                           (block (define [value suboutput subscore]
+                                    (infer-apply-neuf fun
+                                                      [(first l)]
+                                                      ;; advance traces by address i
+                                                      (maybe-subtrace intervene i)
+                                                      (maybe-subtrace target i)
+                                                      output?))
 
-(define map map-issue-20)
+                                  ;; Recur over rest of list
+                                  (define [values output score]
+                                    (re (+ i 1)
+                                        (rest l)))
+                                  [(pair value values)
+                                   (maybe-set-subtrace output i suboutput)
+                                   (+ subscore score)])
+
+                           ;; End of list
+                           [(if (tuple? sequ) (to-tuple l) l)
+                            (trace)
+                            0])))
+
+                     ;; Fire it up
+                     (re 0 (to-list sequ))))))
 
 (define replicate
   (gen [n f]
     (map (gen [i] (f))
          (range n))))
-
-
-;; Experimental
-
-(define opaque
-  (gen [name proc]
-    (inf name
-         (gen [inputs intervene target output]
-           ;; Ignore the traces.
-           (infer-apply proc inputs nil nil nil)))))

--- a/src/metaprob/trace.clj
+++ b/src/metaprob/trace.clj
@@ -475,7 +475,7 @@
 ;; TBD: delete
 
 ;; Marco's merge operator (+).  Commutative and idempotent.
-;;
+
 ;; (trace-merge small large) - when calling, try to make tr1 smaller than tr2,
 ;; because it will be tr1 that is traversed.
 

--- a/src/metaprob/trace.clj
+++ b/src/metaprob/trace.clj
@@ -475,7 +475,7 @@
 ;; TBD: delete
 
 ;; Marco's merge operator (+).  Commutative and idempotent.
-
+;;
 ;; (trace-merge small large) - when calling, try to make tr1 smaller than tr2,
 ;; because it will be tr1 that is traversed.
 

--- a/test/metaprob/infer_test.clj
+++ b/test/metaprob/infer_test.clj
@@ -257,7 +257,7 @@
 (define apply-test
   (gen [thunk]
     (define [val output score]
-      (infer-apply-neuf thunk [] (trace) (trace) true))
+      (infer-apply-neuf thunk (tuple) (trace) (trace) true))
     output))
 
 (define tst1 (gen [] (builtin/add 2 (builtin/mul 3 5))))

--- a/test/metaprob/infer_test.clj
+++ b/test/metaprob/infer_test.clj
@@ -270,4 +270,5 @@
     (is (> (count (addresses-of (apply-test tst1))) 2))
 
     ;; 271
+    (builtin/pprint (apply-test tst2))
     (is (> (count (addresses-of (apply-test tst2))) 100))))

--- a/test/metaprob/infer_test.clj
+++ b/test/metaprob/infer_test.clj
@@ -270,5 +270,4 @@
     (is (> (count (addresses-of (apply-test tst1))) 2))
 
     ;; 271
-    (builtin/pprint (apply-test tst2))
     (is (> (count (addresses-of (apply-test tst2))) 100))))

--- a/test/metaprob/infer_test.clj
+++ b/test/metaprob/infer_test.clj
@@ -142,7 +142,7 @@
                                               50]))
           lifted (infer/inf "lifted" qq)]
       (is (= (lifted 7 8) 15))
-      (let [[answer score] (infer/infer-apply lifted [7 8] no-trace no-trace no-trace)]
+      (let [[answer score] (infer/infer-apply lifted [7 8] nil nil nil)]
         (is (= answer 15))
         (is (= score 50))))))
 

--- a/test/metaprob/trace_test.clj
+++ b/test/metaprob/trace_test.clj
@@ -265,3 +265,15 @@
     (is (> (compare-keys {"abc" {:value 9}} {"abc" {:value 7}}) 0))
     (is (> (compare-keys {"abc" {:value 9} "foo" {:value 17}} {"abc" {:value 9}}) 0))))
 
+(deftest merge!-1
+  (testing "trace-merge!"
+    (let [tr (empty-trace)]
+      (trace-merge! tr {5 {:value 55}})
+      (is (= (trace-get tr 5) 55))
+      (trace-merge! tr {6 {:value 66} 7 {:value 77}})
+      (is (= (trace-get tr 7) 77))
+      (trace-merge! tr {:value 8})
+      (is (= (trace-get tr) 8))
+      (trace-merge! tr {9 {3 {:value 33}}})
+      (is (= (trace-get tr '(9 3)) 33))
+      )))

--- a/test/metaprob/trace_test.clj
+++ b/test/metaprob/trace_test.clj
@@ -277,3 +277,11 @@
       (trace-merge! tr {9 {3 {:value 33}}})
       (is (= (trace-get tr '(9 3)) 33))
       )))
+
+(deftest delete-1
+  (testing "delete"
+    (is (empty-trace? (trace-delete {:value 5})))
+    (is (same-trace-states? (trace-delete {:value 40 50 {:value 60}}) {50 {:value 60}}))
+    (is (same-trace-states? (trace-delete {20 {:value 40 50 {:value 60}}} 20) {20 {50 {:value 60}}}))
+    (is (same-trace-states? (trace-delete {10 {20 {:value 40 50 {:value 60}}}} (list 10 20))
+                            {10 {20 {50 {:value 60}}}}))))


### PR DESCRIPTION
This PR changes infer-eval so that it returns the output trace, instead of altering the provided output trace by side effect. It therefore runs without side effects.

The central changes are to file infer.clj, but the PR also required lots of work on trace.clj.

Addresses #22 and #12