### PR TITLE
Feature leinjupyter demo

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,6 +10,6 @@
                  [criterium "0.4.4"]
                  [org.apache.commons/commons-math3 "3.6.1"]
 		 [incanter "1.9.3"]
-		 [org.clojure/numeric-tower "0.0.4"]]
+		 [org.clojure/math.numeric-tower "0.0.4"]]
   ;; :aot [metaprob.basic-trace]
   )

--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,9 @@
   :jvm-opts ["-Xss50M"]
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [kixi/stats "0.4.0"]
-                 [criterium "0.4.4"]]
+                 [criterium "0.4.4"]
+                 [org.apache.commons/commons-math3 "3.6.1"]
+		 [incanter "1.9.3"]
+		 [org.clojure/numeric-tower "0.0.4"]]
   ;; :aot [metaprob.basic-trace]
   )

--- a/src/metaprob/examples/gaussian-notebook.ipynb
+++ b/src/metaprob/examples/gaussian-notebook.ipynb
@@ -1,0 +1,260 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "*clojure-version*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(require '(incanter core stats charts io))\n",
+    "(require '[clojure.repl :refer :all])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    ";(-> (incanter.stats/sample-normal 10000)\n",
+    ";    incanter.charts/histogram\n",
+    ";    (.createBufferedImage 600 400))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(require '[metaprob.state :as state])\n",
+    "(require '[metaprob.trace :as trace])\n",
+    "(require '[metaprob.sequence :as sequence])\n",
+    "(require '[metaprob.builtin-impl :as impl])\n",
+    "\n",
+    "(require '[metaprob.syntax :refer :all])\n",
+    "(require '[metaprob.builtin :refer :all])\n",
+    "(require '[metaprob.prelude :refer :all])\n",
+    "(require '[metaprob.distributions :refer :all])\n",
+    "(require '[metaprob.interpreters :refer :all])\n",
+    "(require '[metaprob.inference :refer :all])\n",
+    "\n",
+    "(require '[metaprob.infer :as infer])\n",
+    "(require '[metaprob.compositional :as comp])\n",
+    "(require '[metaprob.examples.gaussian :refer :all])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(define example-2D\n",
+    "  (gen []\n",
+    "    (define x (gaussian 0 1))\n",
+    "    (define y (gaussian x 1))\n",
+    "    (+ x y)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(define get-trace\n",
+    "    (gen [proc inputs]\n",
+    "         (define out (empty-trace))\n",
+    "         (infer :procedure proc\n",
+    "                :inputs inputs\n",
+    "                :output-trace out)\n",
+    "         out))\n",
+    "\n",
+    "(define get-example-2D-traces\n",
+    "    (gen [n]\n",
+    "         (take n (repeatedly (gen [] (get-trace example-2D nil))))))\n",
+    "\n",
+    "(define get-xs\n",
+    "    (gen [traces]\n",
+    "         (map (gen [rho] (trace-get rho (addr 0 \"x\" \"gaussian\"))) traces)))\n",
+    "\n",
+    "(define get-ys\n",
+    "    (gen [traces]\n",
+    "         (map (gen [rho] (trace-get rho (addr 1 \"y\" \"gaussian\"))) traces)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(define make-example-2D-trace \n",
+    "    (gen [x y]\n",
+    "        (trace 0 (** (trace \"x\" (** (trace \"gaussian\" x))))\n",
+    "               1 (** (trace \"y\" (** (trace \"gaussian\" y))))\n",
+    "               )))\n",
+    "\n",
+    "(define score-example-2D\n",
+    "    (gen [x y]\n",
+    "         (get (infer :procedure example-2D\n",
+    "                     :inputs nil\n",
+    "                     :target-trace (make-example-2D-trace x y))\n",
+    "              2)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(.createBufferedImage\n",
+    "    (incanter.charts/heat-map score-example-2D\n",
+    "                              -3 3 -3 3\n",
+    "                              :title \"Bivariate Gaussian --- exact density\")\n",
+    "    300 300)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(define example-2D-traces (get-example-2D-traces 1000))\n",
+    "(.createBufferedImage\n",
+    "    (incanter.charts/scatter-plot\n",
+    "        (get-xs example-2D-traces)\n",
+    "        (get-ys example-2D-traces)\n",
+    "        :title \"Bivariate Gaussian generative procedure --- sampled traces\")\n",
+    "    500 500)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(define make-example-2D-density-y-given-x\n",
+    "    (gen [xval]\n",
+    "         (gen [y]\n",
+    "             (get (infer :procedure example-2D\n",
+    "                         :inputs nil\n",
+    "                         :target-trace (make-example-2D-trace xval y))\n",
+    "                  2))\n",
+    "         ))\n",
+    "\n",
+    "(define make-example-2D-sampler-y-given-x\n",
+    "    (gen [xval K]\n",
+    "         (gen []\n",
+    "             (importance-resampling example-2D nil\n",
+    "                                    (trace 0 (** (trace \"x\" (** (trace \"gaussian\" xval)))))\n",
+    "                                    K))\n",
+    "             ))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(.createBufferedImage (incanter.charts/function-plot (make-example-2D-density-y-given-x 1.0)\n",
+    "                                                     -5 5)\n",
+    "                      300 300)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(define example2D-traces-given-x\n",
+    "    (take 1000 (repeatedly (make-example-2D-sampler-y-given-x 1.0 10))))\n",
+    "\n",
+    "(.createBufferedImage\n",
+    "    (incanter.charts/histogram\n",
+    "        (get-ys example2D-traces-given-x)\n",
+    "        :title \"Bivariate Gaussian generative procedure --- sampled traces given x = 1.0\"\n",
+    "        )\n",
+    "    300 300)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(.createBufferedImage\n",
+    "    (incanter.charts/function-plot\n",
+    "        (make-example-2D-density-y-given-x 1.0)\n",
+    "        -2 4\n",
+    "        :title \"Bivariate Gaussian generative procedure --- density given x = 1.0\"\n",
+    "        )\n",
+    "    300 300)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(define example2D-traces-given-x-set2\n",
+    "    (take 1000 (repeatedly (make-example-2D-sampler-y-given-x 0.0 10))))\n",
+    "\n",
+    "(.createBufferedImage\n",
+    "    (incanter.charts/histogram\n",
+    "        (get-ys example2D-traces-given-x-set2)\n",
+    "        :title \"Bivariate Gaussian generative procedure --- sampled traces given x = 0.0\"\n",
+    "        )\n",
+    "    300 300)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(.createBufferedImage\n",
+    "    (incanter.charts/function-plot\n",
+    "        (make-example-2D-density-y-given-x 0.0)\n",
+    "        -3 3\n",
+    "        :title \"Bivariate Gaussian generative procedure --- density given x = 0.0\"\n",
+    "        )\n",
+    "    300 300)"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Lein-Clojure",
+   "language": "clojure",
+   "name": "lein-clojure"
+  },
+  "language_info": {
+   "file_extension": ".clj",
+   "mimetype": "text/x-clojure",
+   "name": "clojure",
+   "version": "1.9.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/src/metaprob/inference.clj
+++ b/src/metaprob/inference.clj
@@ -1,5 +1,3 @@
-;; 4.
-
 (ns metaprob.inference
   (:refer-clojure :only [ns declare])
   (:require [metaprob.syntax :refer :all]


### PR DESCRIPTION
Zane and Jonathan ---

This PR contains an initial very rough exploration of lein-jupyter notebooks with Metaprob. I don't believe this PR is ready to be merged. Rather, I'm showing it to you to start a dialogue, to help us understand how to revise it into something that demonstrates some of the basic functionality in Metaprob (and forces us to write some slightly better plotting utilities along the way).

I'd like Zane and Joshua to help with this. 

The example probabilistic program is a two-variable Gaussian model, where we're showing functionality such as:
- plotting the density on traces induced by the model
- using importance-resampling to infer the distribution of y given x
- comparing importance-resampling to manual enumeration of the density

The plots are done using incanter's support for JFreeCharts, which is minimally usable but ugly.

At minimum, we need to add:
- overlaying density plots on histograms, so that it's more visually obvious that the results are correct
- adding tests that verify that some heuristic measure of the histogram/density difference is low
- stacking the plots better, and using a fixed set of axes across multiple plots, so differences between plots that at present are only visible through differences in the axis labels become easier to see by eye

We probably also want to add:
- an exact inference procedure for the bivariate Gaussian model
- inference queries that condition on y, rather than x, so that it is more obvious that we are trying to find probable executions given constraints

