### PR TITLE
Adding the Poisson distribution

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,11 @@
                  [kixi/stats "0.4.0"]
                  [criterium "0.4.4"]
                  [org.apache.commons/commons-math3 "3.6.1"]
-		 [incanter "1.9.3"]
-		 [org.clojure/math.numeric-tower "0.0.4"]]
+		 [incanter "1.5.7"]
+		 [org.clojure/math.numeric-tower "0.0.4"]
+		 [org.clojure/math.combinatorics "0.1.4"]]
+
+  :plugins [[lein-jupyter "0.1.16"]]
+
   ;; :aot [metaprob.basic-trace]
   )

--- a/project.clj
+++ b/project.clj
@@ -10,6 +10,6 @@
                  [criterium "0.4.4"]
                  [org.apache.commons/commons-math3 "3.6.1"]
 		 [incanter "1.9.3"]
-		 [org.clojure/numeric-tower "0.0.4"]]
+		 [org.clojure/math.numeric-tower "0.0.4"]]
   ;; :aot [metaprob.basic-trace]
   )

--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,9 @@
   :jvm-opts ["-Xss50M"]
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [kixi/stats "0.4.0"]
-                 [criterium "0.4.4"]]
+                 [criterium "0.4.4"]
+                 [org.apache.commons/commons-math3 "3.6.1"]
+		 [incanter "1.9.3"]
+		 [org.clojure/numeric-tower "0.0.4"]]
   ;; :aot [metaprob.basic-trace]
   )

--- a/src/metaprob/distributions.clj
+++ b/src/metaprob/distributions.clj
@@ -3,8 +3,9 @@
   (:require [metaprob.syntax :refer :all])
   (:require [metaprob.builtin :refer :all])
   (:require [metaprob.prelude :refer :all])
-  (:require [metaprob.interpreters :refer :all]))
+  (:require [metaprob.interpreters :refer :all])
   (:require [incanter.stats])
+  ) 
 
 ;; -----------------------------------------------------------------------------
 ;; Distributions (nondeterministic procedures)
@@ -54,26 +55,15 @@
 ;; Poisson
 (define poisson
   (make-inference-procedure-from-sampler-and-scorer
-   "poisson distribution, using Knuth's algorithm, suitable for small(er) values of lambda"
+   "Poisson distribution, using Incanter's implementation"
    (gen [lambda]
-        (assert (< lambda 30) "This implementation is unsuitable for large values of lambda (arbitrarily thresholded at 30, based on a heuristic from John Cook at https://www.johndcook.com/blog/2010/06/14/generating-poisson-random-values/")
-
-        (define poisson-helper (gen [k p L]
-                                    (if (> p L)
-                                      (poisson-helper (+ k 1)
-                                                      (* p (java.lang.Math/random)))
-                                      (- k 1))))
-                                    
-        (define L (java.lang.Math/exp (* -1 lambda)))
-        (poisson-helper 1 (java.lang.Math/random) L)
-        )
-      (gen [lambda k]
-        (assert (< lambda 30) "This implementation (somewhat arbitrarily) assumes lambda is less than 30.")
-        (+ (* k (java.lang.Math/log lambda))
-           (* -1 lambda)
-           (* -1 (org.apache.commons.math3.special.Gamma/logGamma (+ k 1)))))
+   	(incanter.stats/sample-poisson 1 :lambda lambda)
+	)
+   (gen [k [lambda]]
+   	(log (incanter.stats/pdf-poisson k :lambda lambda))
+	)
    ))
-   
+	
 ;; Categorical
 
 (define uniform-sample

--- a/src/metaprob/examples/gaussian-notebook.ipynb
+++ b/src/metaprob/examples/gaussian-notebook.ipynb
@@ -1,0 +1,260 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "*clojure-version*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(require '(incanter core stats charts io))\n",
+    "(require '[clojure.repl :refer :all])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    ";(-> (incanter.stats/sample-normal 10000)\n",
+    ";    incanter.charts/histogram\n",
+    ";    (.createBufferedImage 600 400))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(require '[metaprob.state :as state])\n",
+    "(require '[metaprob.trace :as trace])\n",
+    "(require '[metaprob.sequence :as sequence])\n",
+    "(require '[metaprob.builtin-impl :as impl])\n",
+    "\n",
+    "(require '[metaprob.syntax :refer :all])\n",
+    "(require '[metaprob.builtin :refer :all])\n",
+    "(require '[metaprob.prelude :refer :all])\n",
+    "(require '[metaprob.distributions :refer :all])\n",
+    "(require '[metaprob.interpreters :refer :all])\n",
+    "(require '[metaprob.inference :refer :all])\n",
+    "\n",
+    "(require '[metaprob.infer :as infer])\n",
+    "(require '[metaprob.compositional :as comp])\n",
+    "(require '[metaprob.examples.gaussian :refer :all])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(define example-2D\n",
+    "  (gen []\n",
+    "    (define x (gaussian 0 1))\n",
+    "    (define y (gaussian x 1))\n",
+    "    (+ x y)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(define get-trace\n",
+    "    (gen [proc inputs]\n",
+    "         (define out (empty-trace))\n",
+    "         (infer :procedure proc\n",
+    "                :inputs inputs\n",
+    "                :output-trace out)\n",
+    "         out))\n",
+    "\n",
+    "(define get-example-2D-traces\n",
+    "    (gen [n]\n",
+    "         (take n (repeatedly (gen [] (get-trace example-2D nil))))))\n",
+    "\n",
+    "(define get-xs\n",
+    "    (gen [traces]\n",
+    "         (map (gen [rho] (trace-get rho (addr 0 \"x\" \"gaussian\"))) traces)))\n",
+    "\n",
+    "(define get-ys\n",
+    "    (gen [traces]\n",
+    "         (map (gen [rho] (trace-get rho (addr 1 \"y\" \"gaussian\"))) traces)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(define make-example-2D-trace \n",
+    "    (gen [x y]\n",
+    "        (trace 0 (** (trace \"x\" (** (trace \"gaussian\" x))))\n",
+    "               1 (** (trace \"y\" (** (trace \"gaussian\" y))))\n",
+    "               )))\n",
+    "\n",
+    "(define score-example-2D\n",
+    "    (gen [x y]\n",
+    "         (get (infer :procedure example-2D\n",
+    "                     :inputs nil\n",
+    "                     :target-trace (make-example-2D-trace x y))\n",
+    "              2)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(.createBufferedImage\n",
+    "    (incanter.charts/heat-map score-example-2D\n",
+    "                              -3 3 -3 3\n",
+    "                              :title \"Bivariate Gaussian --- exact density\")\n",
+    "    300 300)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(define example-2D-traces (get-example-2D-traces 1000))\n",
+    "(.createBufferedImage\n",
+    "    (incanter.charts/scatter-plot\n",
+    "        (get-xs example-2D-traces)\n",
+    "        (get-ys example-2D-traces)\n",
+    "        :title \"Bivariate Gaussian generative procedure --- sampled traces\")\n",
+    "    500 500)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(define make-example-2D-density-y-given-x\n",
+    "    (gen [xval]\n",
+    "         (gen [y]\n",
+    "             (get (infer :procedure example-2D\n",
+    "                         :inputs nil\n",
+    "                         :target-trace (make-example-2D-trace xval y))\n",
+    "                  2))\n",
+    "         ))\n",
+    "\n",
+    "(define make-example-2D-sampler-y-given-x\n",
+    "    (gen [xval K]\n",
+    "         (gen []\n",
+    "             (importance-resampling example-2D nil\n",
+    "                                    (trace 0 (** (trace \"x\" (** (trace \"gaussian\" xval)))))\n",
+    "                                    K))\n",
+    "             ))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(.createBufferedImage (incanter.charts/function-plot (make-example-2D-density-y-given-x 1.0)\n",
+    "                                                     -5 5)\n",
+    "                      300 300)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(define example2D-traces-given-x\n",
+    "    (take 1000 (repeatedly (make-example-2D-sampler-y-given-x 1.0 10))))\n",
+    "\n",
+    "(.createBufferedImage\n",
+    "    (incanter.charts/histogram\n",
+    "        (get-ys example2D-traces-given-x)\n",
+    "        :title \"Bivariate Gaussian generative procedure --- sampled traces given x = 1.0\"\n",
+    "        )\n",
+    "    300 300)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(.createBufferedImage\n",
+    "    (incanter.charts/function-plot\n",
+    "        (make-example-2D-density-y-given-x 1.0)\n",
+    "        -2 4\n",
+    "        :title \"Bivariate Gaussian generative procedure --- density given x = 1.0\"\n",
+    "        )\n",
+    "    300 300)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(define example2D-traces-given-x-set2\n",
+    "    (take 1000 (repeatedly (make-example-2D-sampler-y-given-x 0.0 10))))\n",
+    "\n",
+    "(.createBufferedImage\n",
+    "    (incanter.charts/histogram\n",
+    "        (get-ys example2D-traces-given-x-set2)\n",
+    "        :title \"Bivariate Gaussian generative procedure --- sampled traces given x = 0.0\"\n",
+    "        )\n",
+    "    300 300)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(.createBufferedImage\n",
+    "    (incanter.charts/function-plot\n",
+    "        (make-example-2D-density-y-given-x 0.0)\n",
+    "        -3 3\n",
+    "        :title \"Bivariate Gaussian generative procedure --- density given x = 0.0\"\n",
+    "        )\n",
+    "    300 300)"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Lein-Clojure",
+   "language": "clojure",
+   "name": "lein-clojure"
+  },
+  "language_info": {
+   "file_extension": ".clj",
+   "mimetype": "text/x-clojure",
+   "name": "clojure",
+   "version": "1.9.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/src/metaprob/examples/poisson-tests.ipynb
+++ b/src/metaprob/examples/poisson-tests.ipynb
@@ -1,0 +1,96 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "*clojure-version*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(require '(incanter core stats charts io))\n",
+    "(require '[clojure.repl :refer :all])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(require '[metaprob.state :as state])\n",
+    "(require '[metaprob.trace :as trace])\n",
+    "(require '[metaprob.sequence :as sequence])\n",
+    "(require '[metaprob.builtin-impl :as impl])\n",
+    "\n",
+    "(require '[metaprob.syntax :refer :all])\n",
+    "(require '[metaprob.builtin :refer :all])\n",
+    "(require '[metaprob.prelude :refer :all])\n",
+    "(require '[metaprob.distributions :refer :all])\n",
+    "(require '[metaprob.interpreters :refer :all])\n",
+    "(require '[metaprob.inference :refer :all])\n",
+    "\n",
+    "(require '[metaprob.infer :as infer])\n",
+    "(require '[metaprob.compositional :as comp])\n",
+    "(require '[metaprob.examples.gaussian :refer :all])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(.createBufferedImage (incanter.charts/histogram (take 10000 (repeatedly (gen [] (poisson 5))))) 300 300)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(.createBufferedImage\n",
+    "    (incanter.charts/function-plot\n",
+    "        (gen [y]\n",
+    "            (exp (get (infer :procedure poisson\n",
+    "                        :inputs [5]\n",
+    "                        :target-trace (trace :value y))\n",
+    "                     2))\n",
+    "            )\n",
+    "        0 20)\n",
+    "    300 300)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Lein-Clojure",
+   "language": "clojure",
+   "name": "lein-clojure"
+  },
+  "language_info": {
+   "file_extension": ".clj",
+   "mimetype": "text/x-clojure",
+   "name": "clojure",
+   "version": "1.9.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/src/metaprob/inference.clj
+++ b/src/metaprob/inference.clj
@@ -1,5 +1,3 @@
-;; 4.
-
 (ns metaprob.inference
   (:refer-clojure :only [ns declare])
   (:require [metaprob.syntax :refer :all]


### PR DESCRIPTION
Hi Jonathan, Cameron, and Feras,

This pull request adds a generative procedure to Metaprob's distributions library that implements the Poisson distribution. It also includes a Jupyter notebook that contains a quick visual check that the Poisson distribution behaves sanely.

It's not ready to be merged. Specifically, it doesn't have any consistency tests that automatically verify that

1) the logscore and sampler match each other
2) the sampler and logscore match samples from some other reference Poisson distribution implementation

Cameron --- can you implement such tests, and add them to this pull request?

Feras --- can you work with Cameron to see if your GOF testing stuff could help? 

Zane --- can you suggest a way that we can implement these tests using the Juypter notebook interface, so that if a test fails, we can find a notebook and re-evaluate it and quickly visually inspect the data that led to the test failure?

Jonathan --- can you follow along, so that we can adopt whatever approach Cameron, Feras, and Zane converge on, with the other distributions?

Vikash