### PR TITLE
New tracing behavior for non-"inf" code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ pom.xml.asc
 .lein-failures
 .lein_classpath
 .nrepl-port
+.idea
 TAGS
 parsings
 *.tmp

--- a/src/metaprob/builtin.clj
+++ b/src/metaprob/builtin.clj
@@ -162,6 +162,7 @@
 (def positive-infinity Double/POSITIVE_INFINITY)
 (def negative-infinity Double/NEGATIVE_INFINITY)
 (define-foreign-procedure same-trace-states? trace/same-trace-states?)
+(define-foreign-procedure same-states? trace/same-states?)
 
 (defmacro and [& forms] `(clojure.core/and ~@forms))
 (defmacro or [& forms] `(clojure.core/or ~@forms))

--- a/src/metaprob/compositional.clj
+++ b/src/metaprob/compositional.clj
@@ -32,63 +32,45 @@
       (block
         (define imp (trace-get proc "implementation"))
         (imp inputs intervene target output?))
-      (if (and (foreign-procedure? proc)
-               (empty-trace? intervene)
-               (empty-trace? target)
-               (not output?))
+
+      (cond
         ;; Bypass interpreter when there is no need to use it.  Was once
         ;; necessary in order for map and apply to work properly; it might
         ;; be possible to remove this check now that we have
         ;; *ambient-interpreter*.
-        (infer-apply-foreign proc inputs intervene output?)
-        (block
-         ;; Proc is a generative procedure, either 'foreign' (opaque, compiled)
-         ;; or 'native' (interpreted).
-         ;; First call the procedure.  We can't skip the call when there
-         ;; is an intervention, because the call might have side effects.
-         (define [value output score]
-           (cond (native-procedure? proc)
-                 ;; 'Native' generative procedure.  Intervention happens therein.
-                 (infer-apply-native proc inputs intervene target output?)
+        (and (foreign-procedure? proc)
+             (empty-trace? intervene)
+             (empty-trace? target)
+             (not output?))
+        (infer-apply-foreign proc inputs intervene target output?)
 
-                 (foreign-procedure? proc)
-                 (infer-apply-foreign proc inputs intervene output?)
+        ;; Native (interpreted) generative procedure.
+        (native-procedure? proc)
+        (infer-apply-native proc inputs intervene target output?)
 
-                 true
-                 (block (pprint proc)
-                        (error "infer-apply: not a procedure" proc))))
-         (assert (number? score) ["bogus score" proc score])
-         ;; Apply target trace to get modified value and score
-         (if (trace-has? target)
-           [(trace-get target)
-            output
-            (if (trace-has? intervene)
-              ;; Score goes infinitely bad if there is both an
-              ;; intervention and a constraint, and they differ
-              (if (same-trace-states? (trace-get target) value)
-                score
-                (block (print ["value mismatch!"
-                            (trace-get target)
-                            value])
-                    negative-infinity))
-              score)]
-           [value output score]))))))
+        ;; Foreign (opaque, compiled) procedure.
+        (foreign-procedure? proc)
+        (infer-apply-foreign proc inputs intervene target output?)
+
+        ;; Otherwise, this is not a procedure we can interpret.
+        true
+        (block (pprint proc)
+               (error "infer-apply: not a procedure" proc))))))
 
 ;; Invoke a 'foreign' generative procedure, i.e. one written in
 ;; clojure (or Java)
 
 (define infer-apply-foreign
-  (gen [proc inputs intervene output?]
+  (gen [proc inputs intervene target output?]
     ;; 'Foreign' generative procedure
     (define value (generate-foreign proc inputs))
     (define ivalue (if (trace-has? intervene) (trace-get intervene) value))
-    [ivalue
-     (trace)
-     0]))
+    (if (and (trace-has? target) (not (same-states? (trace-get target) ivalue)))
+      [(trace-get target) (trace-set (trace) (trace-get target)) negative-infinity]
+      [ivalue (trace) 0])))
 
 ;; Invoke a 'native' generative procedure, i.e. one written in
 ;; metaprob, with inference mechanics (traces and scores).
-
 (define infer-apply-native
   (gen [proc inputs intervene target output?]
     (define source (trace-subtrace proc "generative-source"))
@@ -203,11 +185,28 @@
 
     (assert (trace? output) output)
 
-    (define v (if (trace-has? intervene)
-                (trace-get intervene)
-                v))
+    (define ivalue (if (trace-has? intervene) (trace-get intervene) v))
+    (define tvalue (if (trace-has? target) (trace-get target) v))
 
-    [v output score]))
+    (cond
+      ; intervention with no disagreeing target
+      (and (trace-has? intervene)
+           (or (not (trace-has? target))
+               (same-states? ivalue tvalue)))
+      [ivalue
+       (if (empty-trace? output) output (trace-set (trace) ivalue))
+       0]
+
+      ; target and value (from intervention or execution) disagree
+      (and (trace-has? target)
+           (not (same-states? ivalue tvalue)))
+      [tvalue
+       (trace-set output tvalue)
+       negative-infinity]
+
+      ; in all other cases, the existing values work fine:
+      true
+      [v output score])))
 
 (define z (gen [n v]
   (assert (tuple? v) ["tuple" v])

--- a/src/metaprob/compositional.clj
+++ b/src/metaprob/compositional.clj
@@ -29,8 +29,9 @@
     (if (and (trace? proc) (trace-has? proc "implementation"))
       ;; Proc is a special inference procedure returned by `inf`.
       ;; Return the value+output+score that the implementation computes.
-      (do (define imp (trace-get proc "implementation"))
-          (imp inputs intervene target output?))
+      (block
+        (define imp (trace-get proc "implementation"))
+        (imp inputs intervene target output?))
       (if (and (foreign-procedure? proc)
                (empty-trace? intervene)
                (empty-trace? target)
@@ -66,7 +67,7 @@
               ;; intervention and a constraint, and they differ
               (if (same-trace-states? (trace-get target) value)
                 score
-                (do (print ["value mismatch!"
+                (block (print ["value mismatch!"
                             (trace-get target)
                             value])
                     negative-infinity))

--- a/src/metaprob/compositional.clj
+++ b/src/metaprob/compositional.clj
@@ -83,9 +83,7 @@
     (define value (generate-foreign proc inputs))
     (define ivalue (if (trace-has? intervene) (trace-get intervene) value))
     [ivalue
-     (if output?
-       (trace-set (trace) ivalue)
-       (trace))
+     (trace)
      0]))
 
 ;; Invoke a 'native' generative procedure, i.e. one written in

--- a/src/metaprob/distributions.clj
+++ b/src/metaprob/distributions.clj
@@ -27,19 +27,6 @@
               (trace))
             score]))))
 
-;; Code translated from class BernoulliOutputPSP(DiscretePSP):
-;;
-;; The larger the weight, the more likely it is that the sample is
-;; true rather than false.
-
-(define flip
-  (make-inference-procedure-from-sampler-and-scorer "flip"
-                (gen [weight] (lt (sample-uniform) weight))
-                (gen [value inputs]
-                  (define weight (nth inputs 0))
-                  (if value
-                    (log weight)
-                    (log1p (sub 0 weight))))))
                   
 
 ;; Uniform
@@ -58,11 +45,25 @@
    "uniform-sample"
    (gen [items]
      ;; items is a metaprob list (or tuple??)
-     (define n (sample-uniform 0 (length items)))
+     (define n (uniform 0 (length items)))
      (nth items (floor n)))
    (gen [item [items]]
      (sub (log (length (clojure.core/filter (gen [x] (= x item)) items)))
         (log (length items))))))
+
+;; Code translated from class BernoulliOutputPSP(DiscretePSP):
+;;
+;; The larger the weight, the more likely it is that the sample is
+;; true rather than false.
+(define flip
+  (make-inference-procedure-from-sampler-and-scorer
+    "flip"
+    (gen [weight] (lt (uniform 0 1) weight))
+    (gen [value inputs]
+      (define weight (nth inputs 0))
+      (if value
+        (log weight)
+        (log1p (sub 0 weight))))))
 
 ;; Cf. CategoricalOutputPSP from discrete.py in Venturecxx
 ;; This is just the one-argument form, so is simpler than what's in Venture.
@@ -75,7 +76,7 @@
      ;; Assume that probabilities add to 1.
      ;; return simulateCategorical(vals[0], args.np_prng(),
      ;;   [VentureInteger(i) for i in range(len(vals[0]))])
-     (define threshold (sample-uniform 0 1))
+     (define threshold (uniform 0 1))
      ;; iterate over probabilities, accumulate running sum, stop when cumu prob > threshold.
      (define scan (gen [i probs running-prob]
                     (if (empty-trace? probs)
@@ -99,7 +100,7 @@
   (make-inference-procedure-from-sampler-and-scorer
    "log-categorical"
    (gen [scores]
-     (define threshold (sample-uniform 0 1))
+     (define threshold (uniform 0 1))
      ;; iterate over probabilities, accumulate running sum, stop when cumu prob > threshold.
      (define scan (gen [i probs running-prob]
                     (define p (+ (first probs) running-prob))

--- a/src/metaprob/prelude.clj
+++ b/src/metaprob/prelude.clj
@@ -173,7 +173,8 @@
    (inf "apply"
         clojure.core/apply   ;model (generative procedure)
         (gen [inputs intervene target output?]
-          (infer-apply (first inputs) (rest inputs) intervene target output?)))
+          ; TODO: allow apply to be n-ary, with last argument a collection
+          (infer-apply (first inputs) (first (rest inputs)) intervene target output?)))
    ;; Kludge
    (gen [proc inputs]
      (clojure.core/apply proc (to-immutable-list inputs)))))

--- a/src/metaprob/syntax.clj
+++ b/src/metaprob/syntax.clj
@@ -90,7 +90,7 @@
                                (if (empty? names)
                                  top-env
                                  (into {"*parent*" {:value top-env}}
-                                       (map (fn [name value] [(str name) {:value value}])
+                                       (map (fn [name value] [name {:value value}])
                                             names
                                             values)))
                                :value "prob prog")
@@ -121,7 +121,7 @@
                       '~exp-trace
                       (impl/make-top-level-env *ns*)
                       ;; Or: {name val name val ... "*parent*" top-env}  ?
-                      '~names
+                      '~(seq (map str names))
                       ~names)))
 
 (defmacro gen

--- a/src/metaprob/syntax.clj
+++ b/src/metaprob/syntax.clj
@@ -89,8 +89,8 @@
                                "environment"
                                (if (empty? names)
                                  top-env
-                                 (into {"*parent*" top-env}
-                                       (map (fn [name value] [name {:value value}])
+                                 (into {"*parent*" {:value top-env}}
+                                       (map (fn [name value] [(str name) {:value value}])
                                             names
                                             values)))
                                :value "prob prog")

--- a/test/metaprob/compositional_test.clj
+++ b/test/metaprob/compositional_test.clj
@@ -157,6 +157,58 @@
         (let [[value2 output2 _] (comp/infer-eval form top intervene no-trace true)]
           (is (= value2 23)))))))
 
+(deftest intervene-3
+  (testing "intervention value is not recorded when it is not usually in output trace"
+    (let [form (from-clojure '(block (define x (add 15 2)) (sub x 2)))
+          intervene (trace-set (builtin/trace) '(0 "x" "add") 23)
+          [value out _] (comp/infer-eval form top intervene no-trace true)]
+      (is (= value 21))
+      (is (empty-trace? out)))))
+
+
+(define tst1 (gen [] (define x (if (distributions/flip 0.5) 0 1)) (+ x 3)))
+(deftest intervene-4
+  (testing "intervention value is recorded when it overwrites normally-traced execution")
+  (let [intervene (trace-set (builtin/trace) '(0 "x") 5)
+        [value out _] (comp/infer-apply tst1 [] intervene no-trace true)]
+    (is (= value 8))
+    (is (and (trace-has? out '(0 "x")) (= 5 (trace-get out '(0 "x")))))))
+
+(deftest intervene-target-agree
+  (testing "intervention and target traces agree"
+    (let [intervene (trace-set (builtin/trace) '(0 "x") 5)
+          target (trace-set (builtin/trace) '(0 "x") 5)
+          [value out s] (comp/infer-apply tst1 [] intervene target true)]
+      (is (= value 8))
+      (is (= s 0))
+      (is (and (trace-has? out '(0 "x")) (= 5 (trace-get out '(0 "x"))))))))
+
+(deftest intervene-target-disagree
+  (testing "intervention and target traces disagree"
+    (let [intervene (trace-set (builtin/trace) '(0 "x") 6)
+          target (trace-set (builtin/trace) '(0 "x") 5)
+          [value out s] (comp/infer-apply tst1 [] intervene target true)]
+      (is (= value 8))
+      (is (= s builtin/negative-infinity))
+      (is (and (trace-has? out '(0 "x")) (= 5 (trace-get out '(0 "x"))))))))
+
+(deftest impossible-target
+  (testing "target is impossible value"
+    (let [target (trace-set (builtin/trace) '(0 "x") 5)
+          [value out s] (comp/infer-apply tst1 [] no-trace target true)]
+      (is (= value 8))
+      (is (= s builtin/negative-infinity))
+      (is (and (trace-has? out '(0 "x")) (= 5 (trace-get out '(0 "x"))))))))
+
+(deftest true-target
+  (testing "target value is the true value"
+    (let [form (from-clojure '(block (define x (add 15 2)) (sub x 2)))
+          target (trace-set (builtin/trace) '(0 "x" "add") 17)
+          [value out s] (comp/infer-eval form top no-trace target true)]
+      (is (= value 15))
+      (is (= s 0))
+      (is (empty-trace? out)))))
+
 ;; Self-application
 
 ;; These have to be defined at top level because only top level defined
@@ -168,16 +220,16 @@
       (infer-apply thunk [] no-trace no-trace true))
     output))
 
-(define tst1 (gen [] (distributions/flip 0.5)))
-(define tst2 (gen [] (apply-test tst1)))
+(define tst2 (gen [] (distributions/flip 0.5)))
+(define tst3 (gen [] (apply-test tst2)))
 
 (deftest infer-apply-self-application
   (testing "apply infer-apply to program that calls infer-apply"
     (binding [*ambient-interpreter* infer-apply]
       ; When we interpret tst1 directly, the value of flip is
       ; recorded at the length-1 address '(distributions/flip).
-      (is (= (count (first (addresses-of (apply-test tst1)))) 1))
+      (is (= (count (first (addresses-of (apply-test tst2)))) 1))
       ; But when we trace the execution of the interpreter, the address
       ; at which the random choice is recorded is significantly longer,
       ; due to the complex chain of function calls initiated by the interpreter.
-      (is (> (count (first (addresses-of (apply-test tst2)))) 10)))))
+      (is (> (count (first (addresses-of (apply-test tst3)))) 10)))))


### PR DESCRIPTION
This PR implements the new default tracing behavior (discussed on 8/28) for Metaprob code (that doesn't have a custom tracer). To summarize:

- No values are recorded in the output trace unless they are explicitly returned (as an output trace) by an inf procedure's implementation.
- That said, all points in a program's execution are addressable, and can be intervened upon or targeted.
- Intervening at a certain point in a program's execution causes the simulated value to be discarded, and the intervention value to be used instead. If the simulated execution produced an output trace, it is overwritten by the intervention trace. If the simulated execution produced no trace, the intervention value is not traced, either.
- Targeting a point in a program's execution has no effect *if* the simulation of the program happens to produce the target value. Otherwise:
   - the simulated value is discarded and the target value is used,
   - the target value is recorded at the root of the simulated output trace, and
   - the score goes to negative infinity.

There are also a couple miscellaneous bug fixes that were necessary to get this working / get all the tests passing:

- `gen` closures that capture local environment now create valid Metaprob environment traces. (The trace structure was just a tad off before; trace keys were symbols instead of strings, and the *parent* environment was recorded as a subtrace rather than a value.)
- `do`, the Clojure keyword, was used at a couple points in `infer-apply`, making it impossible to trace infer-apply's execution as a Metaprob program. Those `do`s have been replaced with `block`
- `apply` worked correctly when run from Clojure, but not from within an interpreted Metaprob program; I added a quick fix that makes it work for invocations of the form (apply f args), but not yet `(apply f arg1 arg2 ... rest-of-args)`, which Jonathan mentioned we might like to support.

Edit: This passes `lein test` tests, but I didn't realize there were others! Travis says those ones are failing (timeout?). I'll look into this locally.
Edit 2: After a long time, the other tests passed. And it looks like Travis agrees--I think the timeout was just too short.