### PR TITLE
Revamp map-to-state to deal with empty traces better

### DIFF
--- a/src/metaprob/state.clj
+++ b/src/metaprob/state.clj
@@ -95,7 +95,7 @@
 
 ;; Constructors
 
-(defn empty-state [] {})    ; 'lein test' passes with () and {} as well
+(defn empty-state [] {})    ; 'lein test' passes with () and [] here as well
 
 (defn set-value [state val]
   (map-to-state (assoc (state-to-map state) :value val)))

--- a/src/metaprob/state.clj
+++ b/src/metaprob/state.clj
@@ -17,6 +17,10 @@
       (vector? val)
       (map? val)))
 
+(defn empty-state? [state]
+  (and (state? state)
+       (empty? state)))
+
 ;; Basic trace operations
 
 (defn has-value? [state]
@@ -62,6 +66,8 @@
             ["no such subtrace" key state])
     val))
 
+;; Returns a seq of keys (without the :value marker)
+
 (defn state-keys [state]
   (if steady?
     (keys-sans-value (state-to-map state))
@@ -89,8 +95,7 @@
 
 ;; Constructors
 
-(defn empty-state []
-  '())
+(defn empty-state [] {})    ; 'lein test' passes with () and {} as well
 
 (defn set-value [state val]
   (map-to-state (assoc (state-to-map state) :value val)))
@@ -99,10 +104,7 @@
   (map-to-state (dissoc (state-to-map state) :value)))
 
 (defn set-subtrace [state key sub]
-  ;; sub is a trace but not necessarily a sub
-  (if (= sub '())
-    state
-    (map-to-state (assoc (state-to-map state) key sub))))
+  (map-to-state (assoc (state-to-map state) key sub)))
 
 (defn clear-subtrace [state key]
   (map-to-state (dissoc (state-to-map state) key)))
@@ -132,23 +134,32 @@
        (= (count tr) 1)
        (contains? tr :value)))
 
-;; Convert hash-map to heterogeneous canonical clojure form
+;; Convert hash-map to heterogeneous canonical clojure form.
+
+;; I'm sorry I failed to record the reason that the 'don't be lazy'
+;; command is there; there must have been a failure at some point that 
+;; I attributed to laziness in these maps.
 
 (defn map-to-state [m]
+  (doseq [entry m] true)    ;Don't be lazy!
   (let [n (count m)]
-    (cond (and (= n 2)
-               (not (= (get m :value :no-value) :no-value))
-               (seq? (get m rest-marker :no-value)))
-          (cons (get m :value)
-                (get m rest-marker))
-
-          (= n 0) '()                   ;Kludge to ensure seq-ness
-
-          (and (= (get m :value :no-value) :no-value)
-               (value-only-trace? (get m 0 :no-value))
-               (value-only-trace? (get m (- n 1) :no-value)))
-          (vec (for [i (range n)] (get (get m i) :value)))
-
-          true (do (assert (map? m) ["expected a map" m])
-                   (doseq [entry m] true)    ;Don't be lazy!
-                   m))))
+    (if (= n 0)
+      (empty-state)
+      (let [value (get m :value :no-value)]
+        (if (= value :no-value)
+          ;; Has no value: could be a vector.
+          (if (every? (fn [i] (value-only-trace? (get m i)))
+                      (range n))
+            (vec (for [i (range n)] (get (get m i) :value)))
+            m)
+          ;; Has value: could be a seq / list.
+          (if (= n 2)
+            (let [rest (get m rest-marker :no-value)]
+              (if (= rest :no-value)
+                m                 ;No "rest", so just an ordinary dict
+                (if (empty-state? rest)
+                  (cons value '())    ;Allow termination in () [] or {}
+                  (if (seq? rest)
+                    (cons value rest)
+                    m))))
+            m))))))

--- a/src/metaprob/trace.clj
+++ b/src/metaprob/trace.clj
@@ -30,9 +30,7 @@
 (defn ok-key? [val]
   (or (number? val)
       (string? val)
-      (boolean? val)
-      ;;(= val nil)
-      ))      ; needed?
+      (boolean? val)))
 
 ;; Generic traces and their subtypes
 

--- a/src/metaprob/trace.clj
+++ b/src/metaprob/trace.clj
@@ -31,7 +31,8 @@
   (or (number? val)
       (string? val)
       (boolean? val)
-      (= val nil)))      ; needed?
+      ;;(= val nil)
+      ))      ; needed?
 
 ;; Generic traces and their subtypes
 
@@ -59,6 +60,7 @@
   (or (ok-key? val)
       (trace? val)
       (keyword? val)
+      (= val nil)
       (top-level-environment? val)
       (proper-function? val)))
 

--- a/test/metaprob/trace_test.clj
+++ b/test/metaprob/trace_test.clj
@@ -204,6 +204,16 @@
         (trace-set! tr adr 19)
         (is (= (trace-get tr adr) 19))))))
 
+(deftest trace-yielding-pair
+  (testing "trace-yielding-pair"
+    (is (= (trace :value 7 "rest" (** '())) '(7)))
+    (is (= (trace :value 7 "rest" (** '(8))) '(7 8)))
+    (is (= (trace :value 7 "rest" (** {})) '(7)))
+    (is (= (trace :value 7 "rest" (** [])) '(7)))
+    (is (map? (trace :value 7 "rest" {})))
+    (is (map? (trace :value 7 "rest" (** '(8)) "frass" 27)))))
+
+
 (deftest same-1
   (testing "object comparison smoke test"
     (is (same-states? 7 7))


### PR DESCRIPTION
Should fix a bug where {} and () were not treated synonymously when building lists.

An incompatible change here is that the default representation for the empty immutable trace is now `{}` instead of `()`.  The tests pass but it's conceivable this could cause problems or break things that ought to work but for which there are no tests. If so, it is easy to change the representation back to `()`.

Also in this PR: nil is no longer allowed as a subtrace key.
