### PR TITLE
Use more of clojure.core in Clojure files

### DIFF
--- a/src/metaprob/builtin.clj
+++ b/src/metaprob/builtin.clj
@@ -172,9 +172,9 @@
 ;--- kludge. based on clojure time macro.
 
 (defn report-on-elapsed-time [tag thunk]
-  (let [start (. System (nanoTime))
+  (let [start (System/nanoTime)
         ret (thunk)
-        t (java.lang.Math/round (/ (double (- (. System (nanoTime)) start)) 1000000000.0))]
+        t (java.lang.Math/round (/ (double (- (System/nanoTime) start)) 1000000000.0))]
     (if (> t 1)
       (print (str tag ": elapsed time " t " sec\n")))
     ret))

--- a/src/metaprob/builtin_impl.clj
+++ b/src/metaprob/builtin_impl.clj
@@ -49,7 +49,7 @@
 
 ;; In metaprob, these are strict functions.
 
-(defn neq [x y] (not (= x y)))
+(def neq not=)
 
 ;; Procedure-related
 
@@ -127,9 +127,9 @@
 (defn metaprob-assert [condition complaint & irritants]
   (binding [*out* *err*]
     (doseq [irritant irritants]
-      (if (mutable-trace? irritant)
-        (do (print "Irritant:")
-            (metaprob-pprint irritant)))))
+      (when (mutable-trace? irritant)
+        (print "Irritant:")
+        (metaprob-pprint irritant))))
   (assert condition
           (if (empty? irritants)
             complaint
@@ -165,10 +165,10 @@
   ;; how to create a new binding in a namespace (a la def)???
   (let [sym (symbol name)
         r (ns-resolve the-ns sym)
-        r (if r r (binding [*ns* the-ns]
-                    (print (format "Assigning %s in %s" sym the-ns))
-                    (eval `(def ~sym))
-                    (ns-resolve the-ns sym)))]
+        r (or r (binding [*ns* the-ns]
+                  (print (format "Assigning %s in %s" sym the-ns))
+                  (eval `(def ~sym))
+                  (ns-resolve the-ns sym)))]
     (ref-set r value)
     nil))
 
@@ -264,7 +264,7 @@
                                      "implementation" implementation)
                       ;; When called from Clojure:
                       (fn [& inputs]
-                        (let [inputs (if (= inputs nil) (list) inputs)]
+                        (let [inputs (if (nil? inputs) (list) inputs)]
                           (nth (implementation inputs (trace) (trace) false)
                                0)))))
 

--- a/src/metaprob/builtin_impl.clj
+++ b/src/metaprob/builtin_impl.clj
@@ -15,7 +15,7 @@
 (declare procedure-name)
 
 (defn addr [& keys]
-  (if (= keys nil)
+  (if (nil? keys)
     '()
     (map (fn [key]
            (if (procedure? key)

--- a/src/metaprob/examples/main.clj
+++ b/src/metaprob/examples/main.clj
@@ -53,11 +53,11 @@
                        (reduc (rest args)))))]
     ;; If nothing is requested, do everything.  This is ugly code, feel free to rewrite
     (let [dict (reduc args)
-          dict (if (not (or (get dict :rejection)
-                            (get dict :importance)
-                            (get dict :mh)
-                            (get dict :quake-rejection)
-                            (get dict :test)))
+          dict (if-not (or (get dict :rejection)
+                           (get dict :importance)
+                           (get dict :mh)
+                           (get dict :quake-rejection)
+                           (get dict :test))
                  (into dict
                        {:rejection true
                         :importance true

--- a/src/metaprob/interpreters.clj
+++ b/src/metaprob/interpreters.clj
@@ -23,17 +23,17 @@
                        target-trace output-trace
                        output-trace?
                        interpreter]}]
-  (let [inputs (if (= inputs nil) [] inputs)
-        intervention-trace (if (= intervention-trace nil)
+  (let [inputs (if (nil? inputs) [] inputs)
+        intervention-trace (if (nil? intervention-trace)
                              null-trace
                              intervention-trace)
-        target-trace (if (= target-trace nil)
+        target-trace (if (nil? target-trace)
                        null-trace
                        target-trace)
-        output-trace? (if (= output-trace? nil)
+        output-trace? (if (nil? output-trace?)
                         true
                         output-trace?)
-        interpreter (if (= interpreter nil)
+        interpreter (if (nil? interpreter)
                       default-interpreter
                       interpreter)
         [value out score]

--- a/src/metaprob/sequence.clj
+++ b/src/metaprob/sequence.clj
@@ -124,7 +124,7 @@
 
 (defn metaprob-list [& things]
   ;; (seq-to-mutable-list things)
-  (if (= things nil)
+  (if (nil? things)
     '()
     things))
 
@@ -143,7 +143,7 @@
           (scan 0))
         ;; This is a kludge but it helps in dealing with [& foo]
         ;;  (where if there are no args, foo is nil instead of ())
-        (= x nil)
+        (nil? x)
         '()
         true
         (assert false ["Expected a tuple or list" x])))

--- a/src/metaprob/sequence.clj
+++ b/src/metaprob/sequence.clj
@@ -74,7 +74,7 @@
     (cond (seq? state) (count state)
           (vector? state) (count state)
           (map? state) (if (pair-as-map? state)
-                         (+ 1 (length (get state rest-marker)))
+                         (inc (length (get state rest-marker)))
                          (assert false ["not a sequence" state]))
           true (assert false ["length wta" tr state]))))
 
@@ -138,7 +138,7 @@
                   (if (trace-has? x i)
                     ;; Cons always returns a clojure seq
                     ;;  and seqs are interpreted as metaprob lists
-                    (cons (trace-get x i) (scan (+ i 1)))
+                    (cons (trace-get x i) (scan (inc i)))
                     '()))]
           (scan 0))
         ;; This is a kludge but it helps in dealing with [& foo]
@@ -165,9 +165,9 @@
     (if (metaprob-pair? thing)
       (letfn [(re [l i]
                 (if (metaprob-pair? l)
-                  (if (= i 0)
+                  (if (zero? i)
                     (metaprob-first l)
-                    (re (metaprob-rest l) (- i 1)))
+                    (re (metaprob-rest l) (dec i)))
                   (assert false [l i (length thing)])))]
         (re thing (int i)))
       (trace-get thing i))

--- a/src/metaprob/state.clj
+++ b/src/metaprob/state.clj
@@ -58,7 +58,7 @@
                     (vector? state) {:value (nth state key)}
                     (map? state) (get state key)
                     true (assert false ["not a state" state])))]
-    (assert (not (= val nil))
+    (assert (some? val)
             ["no such subtrace" key state])
     val))
 
@@ -72,7 +72,7 @@
 
 (defn ^:private keys-sans-value [m]   ;aux for above
   (let [ks (remove #{:value} (keys m))]
-    (if (= ks nil)
+    (if (nil? ks)
       '()
       ks)))
 

--- a/src/metaprob/state.clj
+++ b/src/metaprob/state.clj
@@ -35,8 +35,9 @@
     (cond (seq? state) (first state)
           (vector? state) (assert false "no value")
           (map? state)
-          (do (assert (contains? state :value) ["state has no value" state])
-              (get state :value))
+          (let [value (get state :value ::no-value)]
+            (assert (not= ::no-value value) ["state has no value" state])
+            value)
           :else (assert false ["not a state" state]))))
 
 (defn has-subtrace? [state key]

--- a/src/metaprob/syntax.clj
+++ b/src/metaprob/syntax.clj
@@ -295,7 +295,7 @@
            "else" (** (from-clojure els)))))
 
 (defn from-clojure-block [exp]
-  (assert (not (empty? exp))
+  (assert (seq exp)
           ["empty block" exp])
   (from-clojure-seq (rest exp) "block"))
 
@@ -304,8 +304,8 @@
 (defn from-clojure-definition [exp]
   (let [[_ pattern rhs] exp
         key (if (and (symbol? pattern)
-                     (not (= pattern '_))
-                     (not (= pattern 'pattern)))
+                     (not= pattern '_)
+                     (not= pattern 'pattern))
               (str pattern)
               "definiens")]
     (trace :value "definition"
@@ -313,7 +313,7 @@
            key (** (from-clojure rhs)))))
 
 (defn from-clojure-application [exp]
-  (assert (not (empty? exp))
+  (assert (seq exp)
           ["empty application" exp])
   (from-clojure-seq exp "application"))
 
@@ -389,7 +389,7 @@
       (string? exp)
       (boolean? exp)
       (keyword? exp)
-      (= exp nil)))
+      (nil? exp)))
 
 ;; Don't create variables with these names...
 ;;   (tbd: look for :meta on a Var in this namespace ??)

--- a/src/metaprob/to_clojure.clj
+++ b/src/metaprob/to_clojure.clj
@@ -114,7 +114,7 @@
   (if (and elide-block-sometimes
            (seq? form)
            (= (name (first form)) "block")
-           (not (= (count form) 2)))
+           (not= (count form) 2))
     (rest form)
     (list form)))
 
@@ -160,7 +160,7 @@
 
 (defn gen-to-clojure [pat-trace body-trace nest]
   ;; For readability, allow x y instead of (block x y)
-  (let [nest (if (= (trace/trace-count pat-trace) 0)
+  (let [nest (if (zero? (trace/trace-count pat-trace))
                nest
                (assoc nest :bare false))
         body (form-to-formlist (to-clojure body-trace nest))
@@ -225,13 +225,13 @@
 (defn declarations [subs]
   (assert (seq? subs))
   (let [defs (filter gen-definition? subs)]
-    (do (assert (seq? defs) "no brainer")
+    (assert (seq? defs) "no brainer")
     (if (empty? defs)
       (list)
       (list (qons 'declare (for [d defs]
                              ;; This is wrong - we need to collect all
                              ;; the variables in the pattern.
-                             (to-symbol (definition-name d)))))))))
+                             (to-symbol (definition-name d))))))))
 
 ;; Returns a list of clojure expressions.
 ;; These are at the top level of the file, so not subject to constraints on trace path preservation.
@@ -289,7 +289,7 @@
 
 (defn get-requirements [ns-name]
   (filter (fn [x]
-            (not (= (name (first x)) (name ns-name))))
+            (not= (name (first x)) (name ns-name)))
           '([metaprob.syntax :refer :all]
             [metaprob.builtin :refer :all]
             [metaprob.prelude :refer :all])))

--- a/src/metaprob/trace.clj
+++ b/src/metaprob/trace.clj
@@ -31,7 +31,7 @@
   (or (number? val)
       (string? val)
       (boolean? val)
-      (= val nil)))      ; needed?
+      (nil? val)))      ; needed?
 
 ;; Generic traces and their subtypes
 

--- a/src/metaprob/trace.clj
+++ b/src/metaprob/trace.clj
@@ -530,7 +530,7 @@
 (defn trace-unzip [keyval-seq]
   (into {} (filter (fn [[key sub]]
                      (or (= key :value)
-                         (if (= sub nil)
+                         (if (nil? sub)
                            false
                            (do (assert (trace? sub))
                                true))))
@@ -548,7 +548,7 @@
 (defn kv-pairs-to-map [kvps]
   (if (empty? kvps)
     (state/empty-state)
-    (do (assert (not (empty? (rest kvps))) "odd number of args to trace")
+    (do (assert (seq (rest kvps)) "odd number of args to trace")
         (let [key (first kvps)
               val (first (rest kvps))
               more (kv-pairs-to-map (rest (rest kvps)))]
@@ -590,7 +590,7 @@
     (if (empty? y-keys)
       1
       (let [q (compare-keys (first x-keys) (first y-keys))]
-        (if (= q 0)
+        (if (zero? q)
           (compare-key-lists (rest x-keys) (rest y-keys))
           q)))))
 
@@ -602,7 +602,7 @@
             (if (trace-has? y)
               -1
               0))]
-    (if (= w 0)
+    (if (zero? w)
       (letfn [(lup [x-keys y-keys]
                 (if (empty? x-keys)
                   (if (empty? y-keys)
@@ -611,10 +611,10 @@
                   (if (empty? y-keys)
                     1
                     (let [j (compare-keys (first x-keys) (first y-keys))]
-                      (if (= j 0)
+                      (if (zero? j)
                         (let [q (compare-keys (trace-get x (first x-keys))
                                               (trace-get y (first y-keys)))]
-                          (if (= q 0)
+                          (if (zero? q)
                             (lup (rest x-keys) (rest y-keys))
                             q))
                         j)))))]
@@ -716,7 +716,7 @@
   (let [vertical? (some trace? x)
         indent (str indent " ")]
     (loop [x x first? true]
-      (if (not (empty? x))
+      (if (seq x)
         (do (if (not first?)
               (if vertical?
                 (do (metaprob-newline out)

--- a/src/metaprob/tutorial/jupyter.clj
+++ b/src/metaprob/tutorial/jupyter.clj
@@ -89,7 +89,7 @@
 
 (defn lin-range
   [low high n-intervals]
-  (map (fn [i] (+ low (* i (/ (- high low) (- n-intervals 1)))))
+  (map (fn [i] (+ low (* i (/ (- high low) (dec n-intervals)))))
        (range n-intervals)))
 
 (defn curve-trace


### PR DESCRIPTION
## What does this pull request do?
This pull request updates some of our Clojure files to take advantage of more of `clojure.core`. Specifically:

`(not (empty? x))` ➡️ `(seq x)`
`seq` will return `nil` when called on empty collections, and `nil` is considered false when used in boolean tests. This technique, known as`nil` punning, is the idiomatic way to test whether a `seqable?` collection has anything in it. Often seen in the test portion of an `if-let`. [[1](https://clojuredocs.org/clojure.core/when-let#example-542692cbc026201cdc326c01)]

`(= :no-value (get m k :no-value))` ➡️ `(contains? m k)`
`contains?` is shorter and expresses the intent more clearly, at least to me.

`(. Class classMethod)` ➡️ `(Class/classMethod)`
May as well use some sugar on these.

`(cond … true …)` ➡️ `(cond … :else …)`
Nothing wrong with `true` here, but `:else` is more typical. [[1](https://clojuredocs.org/clojure.core/cond#example-542692c7c026201cdc326966)]

`(if (do …))` ➡️ `(when …)`
`(if (not …) …)` ➡️ `(if-not … …)`
`(not (= …))` ➡️ `(not= …)`
`(if x x y)` ➡️ `(or x y)`
A drizzle of test forms.

`(+ 1 x)` ➡️ `(inc x)`
`(- x 1)` ➡️ `(dec x)`
A sprinkling of numeric helper functions.

`(= 0 x)` ➡️ `(zero? x)`
`(= x nil)` ➡️ `(nil? x)`
Finally a couple predicates.

## Why should we do this?
1. Making our source more idiomatic will ease the on-boarding for new contributors.
1. Leveraging the highly optimized `clojure.core` library _might_ improve performance.