### PR TITLE
Enable Slack notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,10 @@ before_install:
 script:
   - lein test
   - lein run -m metaprob.examples.main test
+notifications:
+  slack:
+    rooms:
+      secure: B9/VRP+CoXvCE97atMXJ3eFKDbLTIxKTyIcJ7BId8pbCEYEBO+5gnmkAfrt+bP/A+MFDsXVOUw990ARSXxh4GI8ydA+KmqQZ39Zm4cB3UpaM6E24f9McO+5ZicFnHg5aSTipZm5dL8cubdv/f3S0G0kSrkAvODEQK7FHBQsf7bJh9TPXUFteWeGjmKtqIBn4R2oOKweBW9LyESwu/5Y7O2BqtD79Z7is9ejzgLqatq+7YqL1p67jRD9icw97ZNt4tT7NQwQzS94U9vgYbTp4qnRzFN5jrTiRfHuqMSsEAVwYZwkoLaHb6OXhU+deZ4FIggJhheuAHA/zHyle7IwkZY4lZFkj8hkwU8f972FqziuWrvPAtDE2xxJ9PW2ze8hpagu+Sm8LZSnKOEnerxrXLJhBTDOwDT8ARCGuO84G/60aE3ajQfiNAzSQvi5n94H0io1I9udlLX7UAG001eTilyzuJQ973b500KzyMbjgvQvzxXiKtoxP/JinHE/FNYmJm2V3csboQoOJ2+ur1I/vHzdmSrPQ6s14gI5Wf3N2JqkwKRbFjqylLgfihfCO5G09Wly8Vc1sZ8KpggFspimJvUZY+0OEZ79nCKD1iT81m43KCgO9tiDsG3xigVqfQRatkV29SdN3b4L+AkrQxaSKzgmoufU6N6nH68sTWIOkWFE=
+      on_success: change
+      on_failure: always
+      on_pull_requests: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: clojure
 lein: lein
 before_install:
+  # The clojure Travis language does not yet include the Clojure CLI tools so we
+  # install them per the instructions here:
+  # https://clojure.org/guides/getting_started
   - curl -O https://download.clojure.org/install/linux-install-1.9.0.394.sh
   - chmod +x linux-install-1.9.0.394.sh
   - sudo ./linux-install-1.9.0.394.sh
@@ -8,8 +11,13 @@ script:
   - lein test
   - lein run -m metaprob.examples.main test
 notifications:
+  # Notification options are documented here:
+  # https://docs.travis-ci.com/user/notifications/#configuring-slack-notifications
   slack:
     rooms:
+      # Because this setting includes our Slack API token it is encrypted. For
+      # more information on using encryption with Travis see the encryption
+      # documentation here: https://docs.travis-ci.com/user/encryption-keys/
       secure: B9/VRP+CoXvCE97atMXJ3eFKDbLTIxKTyIcJ7BId8pbCEYEBO+5gnmkAfrt+bP/A+MFDsXVOUw990ARSXxh4GI8ydA+KmqQZ39Zm4cB3UpaM6E24f9McO+5ZicFnHg5aSTipZm5dL8cubdv/f3S0G0kSrkAvODEQK7FHBQsf7bJh9TPXUFteWeGjmKtqIBn4R2oOKweBW9LyESwu/5Y7O2BqtD79Z7is9ejzgLqatq+7YqL1p67jRD9icw97ZNt4tT7NQwQzS94U9vgYbTp4qnRzFN5jrTiRfHuqMSsEAVwYZwkoLaHb6OXhU+deZ4FIggJhheuAHA/zHyle7IwkZY4lZFkj8hkwU8f972FqziuWrvPAtDE2xxJ9PW2ze8hpagu+Sm8LZSnKOEnerxrXLJhBTDOwDT8ARCGuO84G/60aE3ajQfiNAzSQvi5n94H0io1I9udlLX7UAG001eTilyzuJQ973b500KzyMbjgvQvzxXiKtoxP/JinHE/FNYmJm2V3csboQoOJ2+ur1I/vHzdmSrPQ6s14gI5Wf3N2JqkwKRbFjqylLgfihfCO5G09Wly8Vc1sZ8KpggFspimJvUZY+0OEZ79nCKD1iT81m43KCgO9tiDsG3xigVqfQRatkV29SdN3b4L+AkrQxaSKzgmoufU6N6nH68sTWIOkWFE=
       on_success: change
       on_failure: always


### PR DESCRIPTION
## What does this do?
This pull request enables Travis notifications for the #metaprob channel in the probcomp Slack. I made some configuration judgement calls:

* **Successful builds** will only trigger a Slack notification if the previous build was a failure.
* **Failed builds** will always trigger a Slack notification.
* **Pull request** builds will never trigger a Slack notification.

All of these settings can be changed. Please discuss!

## Why should we do this?
Notifications will alert the entire team to build failures allowing us to respond quicker.