### PR TITLE
Move lein-jupyter plugin out of profile

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject metaprob "0.1.0-SNAPSHOT"
   :jvm-opts ["-Xss50M"] ; Default stack size is 1MB or less, increase to 50
-  :plugins [[lein-tools-deps "0.4.1"]]
+  :plugins [[lein-tools-deps "0.4.1"]
+            [lein-jupyter "0.1.16"]]
   :middleware [lein-tools-deps.plugin/resolve-dependencies-with-deps-edn]
-  :lein-tools-deps/config {:config-files [:install :user :project]}
-  :profiles {:jupyter {:plugins [[lein-jupyter "0.1.16"]]}})
+  :lein-tools-deps/config {:config-files [:install :user :project]})


### PR DESCRIPTION
## What does this do?
Moves the lein-jupyter plugin out of its Leiningen profile. It turns out that lein-jupyter relies on the plugin being at the top level. 

## Why should we do this?
Currently on `master` when you run the command to start Jupyter and open a Clojure notebook it will be unable to connect to the kernel. Merging this down will fix that issue. 

## How do I test this?
1. Start Jupyter with `lein jupyter notebook`.
1. Open `Tutorial.ipynb`.
1. Run the first few cells.