### PR TITLE
Fixes to the tutorial

### DIFF
--- a/src/metaprob/tutorial/Tutorial.ipynb
+++ b/src/metaprob/tutorial/Tutorial.ipynb
@@ -83,7 +83,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "(Any Clojure function can be used without modification in Metaprob. For reasons we'll cover a bit later, however, calling impure Clojure functions that have nondeterministic behavior (e.g., because they generate random values during their execution) must be done with care, in order not to break Metaprob's probabilistic semantics.)"
+    "(Any Clojure function can be used without modification in Metaprob. For reasons we'll cover a bit later, however, calling impure Clojure functions that have nondeterministic behavior (e.g., because they generate random values during their execution) must be done with care, in order not to break Metaprob's probabilistic semantics. Note that this restriction applies also to higher-order Clojure functions supplied with stochastic procedures as arguments.)"
    ]
   },
   {
@@ -108,7 +108,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "(length '(1 2 3))"
+    "(length (list 1 2 3))"
    ]
   },
   {
@@ -255,6 +255,15 @@
     "- a list of names, representing a \"path\" to the desired subtrace.\n",
     "\n",
     "This version of `trace-has?` returns false if the given address is invalid for the trace, or if it is valid but the specified subtrace has no value at its root."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(plot-trace [5 7 9] 200 200)"
    ]
   },
   {
@@ -426,6 +435,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "(plot-trace example-trace)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "; Extract the generative-source subtrace of our example.\n",
     "(plot-trace (trace-subtrace example-trace \"generative-source\"))"
    ]
@@ -480,10 +498,15 @@
     "; Solution\n",
     "(define n-d-vec-ref\n",
     "  (gen [v indices]\n",
+    "    ; If `indices` is non-empty:\n",
     "    (if (trace-has? indices)\n",
+    "        ; Then check whether the first index exists as a subtrace of v\n",
     "        (if (and (trace? v) (trace-has? v (trace-get indices)))\n",
+    "            ; If it does, pull it out and make a recursive call\n",
     "            (n-d-vec-ref (trace-get v (trace-get indices)) (trace-subtrace indices \"rest\"))\n",
+    "            ; If it doesn't, we're out of bounds\n",
     "            :out-of-bounds)\n",
+    "        ; If `indices` is empty, we're done: return v\n",
     "        v)))"
    ]
   },
@@ -675,7 +698,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "(plot-trace (trace/trace-delete [5 7 9] 2) 200)"
+    "(plot-trace (trace-delete [5 7 9] 2) 200)"
    ]
   },
   {
@@ -755,7 +778,7 @@
    "source": [
     "; Trace with arbitrary named subtrace, using (** ...)\n",
     "(plot-trace\n",
-    "    (trace \"a\" (** (trace \"b\" \"c\"))) \n",
+    "    (trace \"a\" (** (trace \"b\" \"c\")) \"b\" 5) \n",
     "  300 100)"
    ]
   },
@@ -1423,7 +1446,7 @@
    "source": [
     "(define [salary tr _]\n",
     " (infer\n",
-    "  :procedure wage-gap-model))\n",
+    "    :procedure wage-gap-model))\n",
     "(smart-plot-trace tr)"
    ]
   },
@@ -1496,6 +1519,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "(addresses-of tr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "(define [sex-adr height-adr salary-adr] (addresses-of tr))"
    ]
   },
@@ -1513,7 +1545,7 @@
    "outputs": [],
    "source": [
     "(histogram \"Model 1\" \n",
-    "  (map count-heads (replicate 100 coin-model-1)) [0 100] 1)"
+    "  (map count-heads (replicate 1000 coin-model-1)) [0 100] 1)"
    ]
   },
   {
@@ -1545,7 +1577,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Although we can sometimes learn interesting things by taking expectations with respect to our models, the most exciting questions usually require _conditioning_ on some piece of data. We might wonder what a person's expected salary is _given that_ she is a woman, or with what probability a person is a woman _given that_ they make $43,000 per year."
+    "Although we can sometimes learn interesting things by taking expectations with respect to our models, the most exciting questions usually require _conditioning_ on some piece of data. We might wonder what a person's expected salary is _given that_ she is a woman, or with what probability a person is a woman _given that_ they make $42,000 per year."
    ]
   },
   {
@@ -1602,7 +1634,7 @@
    "outputs": [],
    "source": [
     "; Create our intervention trace\n",
-    "(define ensure-46k\n",
+    "(define ensure-42k\n",
     "  (trace-set (trace) salary-adr 42000))\n",
     "\n",
     "; Create our accessor (the f to take the expectation of)\n",
@@ -1610,7 +1642,7 @@
     "   (gen [t] (trace-get t height-adr)))\n",
     "\n",
     "; Run the query\n",
-    "(mc-expectation-v3 wage-gap-model ensure-46k get-height 1000)"
+    "(mc-expectation-v3 wage-gap-model ensure-42k get-height 1000)"
    ]
   },
   {
@@ -2064,7 +2096,8 @@
     "(define weighted-samples\n",
     "  (gen [proc target f n]\n",
     "    (define samples (replicate n (gen [] (infer :procedure proc :target-trace target))))\n",
-    "    (map (gen [[o t s]] [(f t) (exp s)]) samples)))\n",
+    "    (map (gen [[o t s]] \n",
+    "              [(f t) (exp s)]) samples)))\n",
     "\n",
     "(define lh-weighting\n",
     "   (gen [proc target f n]\n",
@@ -2114,7 +2147,8 @@
     "    ; Generate particles\n",
     "    (define particles (weighted-samples proc target f n-particles))\n",
     "    ; Choose one at random, with prob. proportional to importance weight\n",
-    "    (define which-particle (categorical (map (gen [[o s]] s) particles)))\n",
+    "    (define sum-of-weights (apply + (map (gen [[_ s]] s) particles)))\n",
+    "    (define which-particle (categorical (map (gen [[o s]] (/ s (+ 1e-10 sum-of-weights))) particles)))\n",
     "    ; Return only the sampled value (not the score)\n",
     "    (define [sampled-value _] (nth particles which-particle))\n",
     "    sampled-value))"
@@ -2159,7 +2193,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Using 20 particles per sample, we get a better approximation to the posterior:"
+    "Using 5 particles per sample, we get a better approximation to the posterior:"
    ]
   },
   {
@@ -2168,12 +2202,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "; 20 particles -- better approx to posterior\n",
+    "; 5 particles -- better approx to posterior\n",
     "(plot-posterior-importance \n",
     "  wage-gap-model\n",
     "  (trace-set (trace) height-adr 73)\n",
     "  (gen [t] (trace-get t salary-adr))\n",
-    "   20 500\n",
+    "   5 500\n",
     "  [30000 60000] 500)"
    ]
   },
@@ -2547,7 +2581,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can increase the number of particles and shift the distribution toward the true posterior, at a cost of spending more time per sample. See if you can play with the number of particles (below, 40) to achieve a good trade-off."
+    "We can increase the number of particles and shift the distribution toward the true posterior, at a cost of spending more time per sample. See if you can play with the number of particles (below, 5) to achieve a good trade-off."
    ]
   },
   {
@@ -2564,7 +2598,7 @@
     "          person-v2\n",
     "          (trace-set (trace) weight-adr 175)\n",
     "          (gen [t] [(trace-get t height-adr) (trace-get t weight-adr)])\n",
-    "          40))))\n",
+    "          5))))\n",
     "\n",
     "\n",
     "(histogram-with-curve\n",
@@ -2811,7 +2845,7 @@
     "          circus-brothers\n",
     "          (trace-set (trace) total-adr observed-height)\n",
     "          extract-heights\n",
-    "          50))))\n",
+    "          10))))\n",
     "\n",
     "(scatter-with-contours\n",
     "  \"Approx. posterior samples of brothers' heights\"\n",
@@ -2916,7 +2950,64 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "(smart-plot-trace (nth (infer :procedure circus-brothers) 1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(smart-plot-trace (nth (infer :procedure custom-biv-gauss :inputs [[0 0] [[1 0] [0 1]]]) 1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[h1-adr h2-adr total-adr]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(define trace-subtrace-or-empty\n",
+    "    (gen [t a]\n",
+    "      (if (trace-has-subtrace? t a) (trace-subtrace t a) (trace))))\n",
+    "\n",
+    "(define custom-circus-brothers\n",
+    "  (inf \"circus-brothers\"\n",
+    "       circus-brothers\n",
+    "       (gen [[] intervene target out?]\n",
+    "        ; h1 h2\n",
+    "        (define [[h1 h2] o _]\n",
+    "          (infer :procedure custom-biv-gauss\n",
+    "                   :intervention-trace (trace-subtrace-or-empty intervene '(0 \"definiens\" \"custom-biv-gauss\"))\n",
+    "                   :target-trace       (trace-subtrace-or-empty target '(0 \"definiens\" \"custom-biv-gauss\"))\n",
+    "                   :inputs \n",
+    "                 (if (trace-has? target total-adr)\n",
+    "                     [[(+ 17.02 (* 0.378 (trace-get target total-adr))) (+ 17.02 (* 0.378 (trace-get target total-adr)))] \n",
+    "                      [[3.7 -0.2966] [-0.2966 3.7]]]\n",
+    "                     [[70 70]\n",
+    "                      [[9 5] [5 9]]])))\n",
+    "        ; total height\n",
+    "        (define total-height\n",
+    "            (cond\n",
+    "                (trace-has? intervene total-adr) (trace-get intervene total-adr)\n",
+    "                (trace-has? target total-adr)    (trace-get target total-adr)\n",
+    "                true (gaussian (+ h1 h2) 3)))\n",
+    "            \n",
+    "        [total-height (trace-set-values-at (trace)\n",
+    "                        total-adr total-height h1-adr h1 h2-adr h2)\n",
+    "         0])))"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
While giving the tutorial to the engineers on 9/18, we discovered some bugs; this commit fixes them and makes minor adjustments to the formatting and wording in a couple places.

- Adds a caveat about using higher-order Clojure functions in Metaprob.
- Plots traces and adds comments to places where people got confused at the in-person tutorial.
- Fixes a couple discrepancies between the prose and code (e.g. "Let's condition on salary = 46k" when the code conditioned on salary=42k)
- Fixes sampling/importance resampling to normalize weights before calling `categorical`. This fix enabled us to decrease the number of particles significantly for many of the examples; now, all SIR queries should run relatively quickly and accurately.
- Adds a solution for the final exercise.