### PR TITLE
Use special logic for rendering floating-point values in trace diagrams

### DIFF
--- a/src/metaprob/tutorial/jupyter.clj
+++ b/src/metaprob/tutorial/jupyter.clj
@@ -12,7 +12,12 @@
 
 (defn trace-as-json
   [tr]
-  (let [base (if (builtin/trace-has? tr) {:value (pr-str (builtin/trace-get tr))} {})
+  (let [base (if (builtin/trace-has? tr)
+               (let [v (builtin/trace-get tr)]
+                 {:value (if (float? v)
+                           (format "%f" v)
+                           (pr-str v))})
+               {})
         children (for [key (builtin/trace-keys tr)]
                    (into (trace-as-json (builtin/trace-subtrace tr key)) [[:name (pr-str key)]]))]
     (into base [[:children (vec children)]])))


### PR DESCRIPTION
This very small PR addresses an issue Ulli brought up: in trace diagrams, floating-point numbers often overflow their boxes. He is using a trace diagram generated by Metaprob in his slides, so wanted this cleaned up.

This PR achieves this by using `(format "%f" ...)`, which truncates its output, if the value being rendered is a float, and using `(pr-str ...)` (as we did before) otherwise.