### PR TITLE
add mem and some tests for it

### DIFF
--- a/src/metaprob/examples/all.clj
+++ b/src/metaprob/examples/all.clj
@@ -14,6 +14,7 @@
   (:require [metaprob.syntax :refer :all])
   (:require [metaprob.builtin :refer :all])
   (:require [metaprob.prelude :refer :all])
+  (:require [metaprob.mem :refer :all])
   (:require [metaprob.distributions :refer :all])
   (:require [metaprob.interpreters :refer :all])
   (:require [metaprob.inference :refer :all])

--- a/src/metaprob/mem.clj
+++ b/src/metaprob/mem.clj
@@ -1,0 +1,62 @@
+(ns metaprob.mem
+  (:refer-clojure :only [declare ns])
+  (:require [metaprob.syntax :refer :all])
+  (:require [metaprob.builtin :refer :all])
+  (:require [metaprob.prelude :refer :all])
+  (:require [metaprob.interpreters :refer :all]))
+
+;; For now, the function to be memoized must take exactly one
+;; argument, and that argument must be acceptable as a trace
+;; key (number, string, boolean).
+;;
+;; In the future, traces might be changed to allow structured values
+;; as keys, in which case these deficiencies can be corrected.
+
+;; TBD: intervention and target
+;; TBD: protect for parallelism
+
+(define traces-stored-under-key "memoized-traces")
+
+(define with-memoized
+  (inf "with-memoized"
+       (gen [fun proc] (proc fun))      ;???? not quite right
+       (gen [[fun proc] intervene target output?]
+         (define value-cache (mutable-trace))
+         (define trace-cache (mutable-trace))
+         (define total-score (mutable-trace :value 0))
+         (define intervene-cache (maybe-subtrace intervene traces-stored-under-key))
+         (define target-cache (maybe-subtrace target traces-stored-under-key))
+         ;; Populate cache with values from intevention and target traces
+         (define [valu out sco]
+           (infer :procedure proc
+                  :inputs
+                  [(inf "memoized"
+                        fun             ;????
+                        (gen [[key] _ _ o?]   ;Ignore intervention & target traces - no randomness here
+                          ;; We're faking a with-address here
+                          [(if (trace-has? value-cache key)
+                             (trace-get value-cache key)
+                             (block (define [valu out sco]
+                                      (infer :procedure fun
+                                             :inputs [key]
+                                             :intervention-trace (maybe-subtrace intervene-cache key)
+                                             :target-trace (maybe-subtrace target-cache key)
+                                             :output-trace? o?))
+                                    (trace-set! value-cache key valu)
+                                    (if (and out (not (empty-trace? out)))
+                                      (trace-set-subtrace! trace-cache key out))
+                                    (trace-set! total-score
+                                                (+ (trace-get total-score) sco))
+                                    valu))
+                           (trace)
+                           0]))]
+                  :intervention-trace intervene
+                  :target-trace target
+                  :output-trace? output?))
+         [valu
+          (if output?
+            (maybe-set-subtrace out
+                                traces-stored-under-key    ; Possible collision here (unlikely)
+                                (to-immutable trace-cache))
+            nil)
+          (+ sco (trace-get total-score))])))

--- a/src/metaprob/trace.clj
+++ b/src/metaprob/trace.clj
@@ -405,13 +405,11 @@
 ;; Side effects.
 
 (defn ^:private trace-set-direct-subtrace! [tr key sub]
-  (assert (mutable-trace? sub) sub)
   (trace-swap! tr
                (fn [state]
                  (trace-set-direct-subtrace state key sub))))
 
 (defn trace-set-subtrace! [tr adr sub]
-  (assert (mutable-trace? sub) sub)
   (if (seq? adr)
     (loop [tr tr adr adr]
       (let [[head & tail] adr]
@@ -429,14 +427,12 @@
     (trace-set-direct-subtrace! tr adr sub)))
 
 (defn ^:private trace-set-value! [tr val]
-  (assert (mutable-trace? tr) tr)
   (assert (ok-value? val) val)            ;REMOVE
   (trace-swap! tr
                (fn [state]
                  (state/set-value state val))))
 
 (defn ^:private trace-set-value-at! [tr adr val] ;cf. trace-get
-  (assert (mutable-trace? tr) tr)
   (let [adr (if (seq? adr) adr (list adr))]
     (loop [tr tr adr adr]
       (if (empty? adr)
@@ -499,7 +495,6 @@
     (trace-merge mutable tr trace-merge!-maybe)))
 
 (defn trace-merge! [mutable tr]
-  (assert (mutable-trace? mutable) mutable)
   (trace-merge!-maybe mutable tr))
 
 ;; -----------------------------------------------------------------------------

--- a/test/metaprob/mem_test.clj
+++ b/test/metaprob/mem_test.clj
@@ -1,0 +1,91 @@
+(ns metaprob.mem-test
+  (:require [clojure.test :refer :all]
+            [metaprob.trace :refer :all]
+            [metaprob.sequence :refer :all]
+            [metaprob.syntax :refer :all]
+            [metaprob.builtin-impl :as impl]
+            [metaprob.distributions :refer :all]
+            [metaprob.interpreters :refer :all]
+            [metaprob.mem :refer :all]))
+
+;; ---- Null case: deterministic function
+
+(deftest mem-value
+  (testing "see whether memoized function gives the right values"
+    (define fun (gen [x] (+ x 2)))
+    (is (= (with-memoized fun
+             (gen [mfun]
+               [(mfun 1) (mfun 4) (mfun 1)]))
+           [3 6 3]))))
+
+;; ---- Deterministic function, check to make sure values get cached
+
+(define detector (mutable-trace))
+(define fun
+  (gen [x]
+    (trace-set! detector (+ (trace-get detector) 1))
+    (+ x 2)))
+
+(deftest mem-cache-value
+  (testing "see whether memoized function caches the computation"
+    (trace-set! detector 0)
+    (is (= (with-memoized fun
+             (gen [mfun]
+               [(mfun 1) (mfun 4) (mfun 1) (mfun 4)]))
+           [3 6 3 6]))
+    (is (= (trace-get detector) 2))))
+
+;; ---- Nondeterministic function interpreted using infer
+
+(define unit-uniform (gen [arg] (uniform 0 1)))
+(define doit
+  (gen []
+    (with-memoized unit-uniform
+      (gen [uu]
+        [(uu 1) (uu 1) (uu 1) (uu 2)]))))
+
+(deftest mem-cache-value-2
+  (testing "basic test of mem functionality, calling infer"
+    (define [result _ _]
+      (infer :procedure doit
+             :inputs []
+             ;; Force use of meta-circular interpreter
+             :output-trace? true))
+    (is (= (nth result 0) (nth result 1)))
+    (is (not (= (nth result 2) (nth result 3))))))
+
+;; If there are four samples, we expect the score to be... on average
+
+(deftest mem-cache-score
+  (testing "basic test of mem functionality, calling infer, checking score"
+    (define [result output score]
+      (infer :procedure doit
+             :inputs []
+             ;; Force use of meta-circular interpreter
+             :output-trace? true))
+    (is (> score -5))                   ;Very occasional test failures
+    (define cache (trace-subtrace output (list "with-memoized" traces-stored-under-key)))
+    (is (= (trace-count cache) 2))
+    (is (> (trace-get cache (list 2 "uniform")) 0))
+    (metaprob-pprint output)))
+
+;; Test ability to intervene
+
+(deftest mem-intervene
+  (testing "can we intervene on a memoized function?"
+    (define cache-before (trace 1 (** (trace "uniform" 0.4))))
+    (define intervene
+      (trace "with-memoized"
+             (** (trace traces-stored-under-key
+                        (** cache-before)))))
+             
+    (define [result output score]
+      (infer :procedure doit
+             :inputs []
+             :intervention-trace intervene))
+
+    (define cache-after (trace-subtrace output (list "with-memoized" traces-stored-under-key)))
+
+    (is (= (trace-get cache-after (list 1 "uniform"))
+           (trace-get cache-before (list 1 "uniform"))))))
+


### PR DESCRIPTION
## What does this do?

This PR defines the `mem` operator, which one finds in other probabilistic programming languages. We need `mem` in order to bring metaprob to the level of competence and coverage that we see in, say, Church. In particular, `mem` is required to implement CRP (Chinese Restaurant Process).

`mem` is implemented as an `inf` procedure. 

Note that this version of `mem`, unlike the one in python-metaprob, creates the memoized procedure in a higher-order function `with-memoized`, and the procedure is only intended to be used there.  It does not make any sense for a memoized procedure to work outside of the current model, and this restructuring is one way to prevent that.

This PR is intended to close #40.

Credit to @alex-lew for his help.

## Pros and cons

### Pros

We ought to be in a position now to run the metaprob CRP demonstration (#40) from python-metaprob, and similar examples.

### Cons

There may be ways to modularize it; after all, in python-metaprob, it was defined in ordinary metaprob, using `this` and `with-address` - the definition there was much simpler.  So consider a rewrite possible in the future. Also, I think the trace structure is up for grabs.

Oops - I forgot to add the error check that complains if you try to use the memoized function after the call to `with-memoized` completes.  I suggest we merge this PR anyhow, and record this oversight as a bug.

## How do I test this?

`mem` is tested in the usual way, via the test system.  What I do is: `lein test metaprob.mem-test`
