### PR TITLE
Add automatic differentiation

### DIFF
--- a/src/metaprob/autodiff.cljc
+++ b/src/metaprob/autodiff.cljc
@@ -148,12 +148,24 @@
           (empty? (rest xs)) ((lift-real->real f df-dx) (first xs))
           :else (reduce (lift-real*real->real f df-dx1 df-dx2) xs))))
 
-(defn value [x]
-  (if (bare-number? x) x (:value x)))
+(defn recursive-unnest-value [x]
+  "Recursively unnest the `value` field of a `value-with-derivative`.
+
+  The return value is `(:value (:value (... (:value x))))`, where the number of
+  nestings used is the smallest such that the return value is not a map.  In
+  particular, if `x` is already not a map, then the return value is `x`
+  itself." 
+  (if (map? x)
+    (recur (:value x))
+    x))
+
+(defn shallow-unnest-value [x]
+  "Return the `value` field. Acts as the identity if the argument is not a map."
+  (if (map? x) (:value x) x)
 
 
 (defn lift-real-n->boolean [f]
-  (fn [& xs] (apply f (map value xs))))
+  (fn [& xs] (apply f (map shallow-unnest-value xs))))
 
 
 (def + (lift-real-n->real clojure.core/+

--- a/src/metaprob/autodiff.cljc
+++ b/src/metaprob/autodiff.cljc
@@ -27,12 +27,16 @@
 
 (def bare-number? clojure.core/number?)
 
-;; Take a unary operation f on numbers
-;; and lift it to work with dual numbers.
-;; Note that df-dx should itself be a lifted
-;; function for computing the derivative of f
-;; at a point.
 (defn lift-real->real
+  "Lift a unary operation `f` on numbers to also support `value-with-derivative`s.
+
+  Note that `df-dx` should itself be a lifted function (i.e. must allow its
+  argument to be either a bare number or a `value-with-derivative`) that
+  computes the derivative of `f` at a point.
+
+  The returned function accepts either a bare number or a
+  `value-with-derivative` as its input, and produces an output of the same type
+  and the same nesting level (`:autodiff/tag`)."
   [f df-dx]
   (fn new-f [x]
     (if (bare-number? x)

--- a/src/metaprob/autodiff.cljc
+++ b/src/metaprob/autodiff.cljc
@@ -2,10 +2,10 @@
   (:refer-clojure :exclude [+ * - / == < > <= >= zero? number? pos? neg?]))
 
 ;; Dual numbers represent computations dependent on a value with respect to which we are differentiating.
-;; dual contains the current derivative; primal contains the current value; and tag is a special tag
+;; derivative contains the current derivative; value contains the current value; and tag is a special tag
 ;; that helps distinguish between multiple "levels" of nested differentiations.
-(defn make-dual-number [tag primal dual]
-  {:tag tag :primal primal :dual dual})
+(defn make-dual-number [tag value derivative]
+  {:tag tag :value value :derivative derivative})
 
 (declare * + - /)
 
@@ -19,11 +19,11 @@
 (defn lift-real->real
   [f df-dx]
   (fn new-f [x]
-    (if (map? x)
+    (if (non-dual? x)
+      (f x)
       (make-dual-number (:tag x)
-                        (new-f (:primal x))
-                        (* (df-dx (:primal x)) (:dual x)))
-      (f x))))
+                        (new-f (:value x))
+                        (* (df-dx (:value x)) (:derivative x))))))
 
 ;; Lift a binary operation on numbers to work
 ;; with dual numbers. We have to consider several
@@ -37,18 +37,18 @@
       (or (and (map? x1) (non-dual? x2))
           (and (map? x1) (map? x2) (clojure.core/> (:tag x1) (:tag x2))))
       (make-dual-number (:tag x1)
-                        (new-f (:primal x1) x2)
-                        (* (df-dx1 (:primal x1) x2) (:dual x1)))
+                        (new-f (:value x1) x2)
+                        (* (df-dx1 (:value x1) x2) (:derivative x1)))
       (or (and (non-dual? x1) (map? x2))
           (and (map? x1) (map? x2) (clojure.core/< (:tag x1) (:tag x2))))
       (make-dual-number (:tag x2)
-                        (new-f x1 (:primal x2))
-                        (* (df-dx2 x1 (:primal x2)) (:dual x2)))
+                        (new-f x1 (:value x2))
+                        (* (df-dx2 x1 (:value x2)) (:derivative x2)))
       (and (map? x1) (map? x2) (= (:tag x1) (:tag x2)))
       (make-dual-number (:tag x1)
-                        (new-f (:primal x1) (:primal x2))
-                        (+ (* (df-dx1 (:primal x1) (:primal x2)) (:dual x1))
-                           (* (df-dx2 (:primal x1) (:primal x2)) (:dual x2)))))))
+                        (new-f (:value x1) (:value x2))
+                        (+ (* (df-dx1 (:value x1) (:value x2)) (:derivative x1))
+                           (* (df-dx2 (:value x1) (:value x2)) (:derivative x2)))))))
 
 (defn lift-real*real*real->real
   [f df-dx1 df-dx2 df-dx3]
@@ -61,47 +61,47 @@
            (or (non-dual? x2)(clojure.core/< (:tag x2) (:tag x1)))
            (or (non-dual? x3) (clojure.core/< (:tag x3) (:tag x1))))
       (make-dual-number (:tag x1)
-                        (new-f (:primal x1) x2 x3)
-                        (* (df-dx1 (:primal x1) x2 x3) (:dual x1)))
+                        (new-f (:value x1) x2 x3)
+                        (* (df-dx1 (:value x1) x2 x3) (:derivative x1)))
 
       (and (map? x2)
            (or (non-dual? x1) (clojure.core/< (:tag x1) (:tag x2)))
            (or (non-dual? x3) (clojure.core/< (:tag x3) (:tag x2))))
       (make-dual-number (:tag x2)
-                        (new-f x1 (:primal x2) x3)
-                        (* (df-dx2 x1 (:primal x2) x3) (:dual x2)))
+                        (new-f x1 (:value x2) x3)
+                        (* (df-dx2 x1 (:value x2) x3) (:derivative x2)))
 
       (and (map? x3)
            (or (non-dual? x1) (clojure.core/< (:tag x1) (:tag x3)))
            (or (non-dual? x2) (clojure.core/< (:tag x2) (:tag x3))))
       (make-dual-number (:tag x3)
-                        (new-f x1 x2 (:primal x3))
-                        (* (df-dx3 x1 x2 (:primal x3)) (:dual x3)))
+                        (new-f x1 x2 (:value x3))
+                        (* (df-dx3 x1 x2 (:value x3)) (:derivative x3)))
 
       (and (map? x1) (map? x2) (= (:tag x1) (:tag x2)) (or (non-dual? x3) (clojure.core/< (:tag x3) (:tag x1))))
       (make-dual-number (:tag x1)
-                        (new-f (:primal x1) (:primal x2) x3)
-                        (+ (* (df-dx1 (:primal x1) (:primal x2) x3) (:dual x1))
-                           (* (df-dx2 (:primal x1) (:primal x2) x3) (:dual x2))))
+                        (new-f (:value x1) (:value x2) x3)
+                        (+ (* (df-dx1 (:value x1) (:value x2) x3) (:derivative x1))
+                           (* (df-dx2 (:value x1) (:value x2) x3) (:derivative x2))))
 
       (and (map? x1) (map? x3) (= (:tag x1) (:tag x3)) (or (non-dual? x2) (clojure.core/< (:tag x2) (:tag x1))))
       (make-dual-number (:tag x1)
-                        (new-f (:primal x1) x2 (:primal x3))
-                        (+ (* (df-dx1 (:primal x1) x2 (:primal x3)) (:dual x1))
-                           (* (df-dx3 (:primal x1) x2 (:primal x3)) (:dual x3))))
+                        (new-f (:value x1) x2 (:value x3))
+                        (+ (* (df-dx1 (:value x1) x2 (:value x3)) (:derivative x1))
+                           (* (df-dx3 (:value x1) x2 (:value x3)) (:derivative x3))))
 
       (and (map? x2) (map? x3) (= (:tag x2) (:tag x3)) (or (non-dual? x1) (clojure.core/< (:tag x1) (:tag x2))))
       (make-dual-number (:tag x2)
-                        (new-f x1 (:primal x2) (:primal x3))
-                        (+ (* (df-dx2 x1 (:primal x2) (:primal x3)) (:dual x2))
-                           (* (df-dx3 x1 (:primal x2) (:primal x3)) (:dual x3))))
+                        (new-f x1 (:value x2) (:value x3))
+                        (+ (* (df-dx2 x1 (:value x2) (:value x3)) (:derivative x2))
+                           (* (df-dx3 x1 (:value x2) (:value x3)) (:derivative x3))))
 
       (and (map? x1) (map? x2) (map? x3) (= (:tag x1) (:tag x2) (:tag x3)))
       (make-dual-number (:tag x2)
-                        (new-f (:primal x1) (:primal x2) (:primal x3))
-                        (+ (* (df-dx1 (:primal x1) (:primal x2) (:primal x3)) (:dual x1))
-                           (* (df-dx2 (:primal x1) (:primal x2) (:primal x3)) (:dual x2))
-                           (* (df-dx3 (:primal x1) (:primal x2) (:primal x3)) (:dual x3)))))))
+                        (new-f (:value x1) (:value x2) (:value x3))
+                        (+ (* (df-dx1 (:value x1) (:value x2) (:value x3)) (:derivative x1))
+                           (* (df-dx2 (:value x1) (:value x2) (:value x3)) (:derivative x2))
+                           (* (df-dx3 (:value x1) (:value x2) (:value x3)) (:derivative x3)))))))
 
 ;; For functions like + and *, which can take multiple arguments
 (defn lift-real-n->real [f df-dx1 df-dx2]
@@ -117,12 +117,12 @@
           (empty? (rest xs)) ((lift-real->real f df-dx) (first xs))
           :else (reduce (lift-real*real->real f df-dx1 df-dx2) xs))))
 
-(defn primal [x]
-  (if (non-dual? x) x (:primal x)))
+(defn value [x]
+  (if (non-dual? x) x (:value x)))
 
 
 (defn lift-real-n->boolean [f]
-  (fn [& xs] (apply f (map primal xs))))
+  (fn [& xs] (apply f (map value xs))))
 
 
 (def + (lift-real-n->real clojure.core/+
@@ -212,32 +212,28 @@
 
 (def e (atom 0))
 
-;; Helper function used by `diff` and `gradient-vector`.
+;; Helper function used by `diff` and `gradient`.
 ;; Returns [(f x) (df-dx x)]
-(defn forward-mode [map-independent map-dependent f x x-perturbation]
+(defn forward-mode [apply-2 apply-1 f x x-deriv]
   ;; Based on R6RS-ad, thus doesn't support tangent vector mode
   (swap! e inc)
-  (let [y-forward (f (map-independent (fn [x x-dual] (make-dual-number @e x x-dual))
-                                      x
-                                      x-perturbation))]
+  (let [y-forward (f (apply-2 (fn [x x-deriv] (make-dual-number @e x x-deriv)) x x-deriv))]
     (swap! e dec)
-    [(map-dependent (fn [y-forward]
-                      (if (or (not (map? y-forward))
-                              (clojure.core/< (:tag y-forward) @e))
-                        y-forward
-                        (:primal y-forward)))
-                    y-forward)
-     (map-dependent (fn [y-forward]
-                      (if (or (not (map? y-forward))
-                              (clojure.core/< (:tag y-forward) @e))
-                        0
-                        (:dual y-forward)))
-                    y-forward)]))
+    [(apply-1 (fn [y-forward]
+                (if (or (not (map? y-forward)) (clojure.core/< (:tag y-forward) @e))
+                  y-forward
+                  (:value y-forward)))
+              y-forward)
+     (apply-1 (fn [y-forward]
+                (if (or (not (map? y-forward)) (clojure.core/< (:tag y-forward) @e))
+                  0
+                  (:derivative y-forward)))
+              y-forward)]))
 
 ;; Our "map" functions just apply `f`.
 (defn diff [f]
   (fn [x]
-    (second (forward-mode (fn [f x x-dual] (f x x-dual))
+    (second (forward-mode (fn [f x x-deriv] (f x x-deriv))
                           (fn [f y-forward] (f y-forward))
                           f x 1))))
 

--- a/src/metaprob/autodiff.cljc
+++ b/src/metaprob/autodiff.cljc
@@ -19,9 +19,9 @@
   # Fields
   `value`: the value `f(x)`
   `derivative`: the derivative `f'(x)`
-  `tag`: internal identifier indicating nesting level within the autodiff
-         computation"
-  {:tag tag :value value :derivative derivative})
+  `autodiff/tag`: internal identifier indicating nesting level within the
+                  autodiff computation"
+  {::tag tag :value value :derivative derivative})
 
 (declare * + - /)
 
@@ -37,7 +37,7 @@
   (fn new-f [x]
     (if (bare-number? x)
       (f x)
-      (value-with-derivative (:tag x)
+      (value-with-derivative (::tag x)
                              (new-f (:value x))
                              (* (df-dx (:value x)) (:derivative x))))))
 
@@ -51,17 +51,17 @@
       (and (bare-number? x1) (bare-number? x2))
       (f x1 x2)
       (or (and (map? x1) (bare-number? x2))
-          (and (map? x1) (map? x2) (clojure.core/> (:tag x1) (:tag x2))))
-      (value-with-derivative (:tag x1)
+          (and (map? x1) (map? x2) (clojure.core/> (::tag x1) (::tag x2))))
+      (value-with-derivative (::tag x1)
                              (new-f (:value x1) x2)
                              (* (df-dx1 (:value x1) x2) (:derivative x1)))
       (or (and (bare-number? x1) (map? x2))
-          (and (map? x1) (map? x2) (clojure.core/< (:tag x1) (:tag x2))))
-      (value-with-derivative (:tag x2)
+          (and (map? x1) (map? x2) (clojure.core/< (::tag x1) (::tag x2))))
+      (value-with-derivative (::tag x2)
                              (new-f x1 (:value x2))
                              (* (df-dx2 x1 (:value x2)) (:derivative x2)))
-      (and (map? x1) (map? x2) (= (:tag x1) (:tag x2)))
-      (value-with-derivative (:tag x1)
+      (and (map? x1) (map? x2) (= (::tag x1) (::tag x2)))
+      (value-with-derivative (::tag x1)
                              (new-f (:value x1) (:value x2))
                              (+ (* (df-dx1 (:value x1) (:value x2)) (:derivative x1))
                                 (* (df-dx2 (:value x1) (:value x2)) (:derivative x2)))))))
@@ -74,46 +74,46 @@
       (f x1 x2 x3)
 
       (and (map? x1)
-           (or (bare-number? x2)(clojure.core/< (:tag x2) (:tag x1)))
-           (or (bare-number? x3) (clojure.core/< (:tag x3) (:tag x1))))
-      (value-with-derivative (:tag x1)
+           (or (bare-number? x2)(clojure.core/< (::tag x2) (::tag x1)))
+           (or (bare-number? x3) (clojure.core/< (::tag x3) (::tag x1))))
+      (value-with-derivative (::tag x1)
                              (new-f (:value x1) x2 x3)
                              (* (df-dx1 (:value x1) x2 x3) (:derivative x1)))
 
       (and (map? x2)
-           (or (bare-number? x1) (clojure.core/< (:tag x1) (:tag x2)))
-           (or (bare-number? x3) (clojure.core/< (:tag x3) (:tag x2))))
-      (value-with-derivative (:tag x2)
+           (or (bare-number? x1) (clojure.core/< (::tag x1) (::tag x2)))
+           (or (bare-number? x3) (clojure.core/< (::tag x3) (::tag x2))))
+      (value-with-derivative (::tag x2)
                              (new-f x1 (:value x2) x3)
                              (* (df-dx2 x1 (:value x2) x3) (:derivative x2)))
 
       (and (map? x3)
-           (or (bare-number? x1) (clojure.core/< (:tag x1) (:tag x3)))
-           (or (bare-number? x2) (clojure.core/< (:tag x2) (:tag x3))))
-      (value-with-derivative (:tag x3)
+           (or (bare-number? x1) (clojure.core/< (::tag x1) (::tag x3)))
+           (or (bare-number? x2) (clojure.core/< (::tag x2) (::tag x3))))
+      (value-with-derivative (::tag x3)
                              (new-f x1 x2 (:value x3))
                              (* (df-dx3 x1 x2 (:value x3)) (:derivative x3)))
 
-      (and (map? x1) (map? x2) (= (:tag x1) (:tag x2)) (or (bare-number? x3) (clojure.core/< (:tag x3) (:tag x1))))
-      (value-with-derivative (:tag x1)
+      (and (map? x1) (map? x2) (= (::tag x1) (::tag x2)) (or (bare-number? x3) (clojure.core/< (::tag x3) (::tag x1))))
+      (value-with-derivative (::tag x1)
                              (new-f (:value x1) (:value x2) x3)
                              (+ (* (df-dx1 (:value x1) (:value x2) x3) (:derivative x1))
                                 (* (df-dx2 (:value x1) (:value x2) x3) (:derivative x2))))
 
-      (and (map? x1) (map? x3) (= (:tag x1) (:tag x3)) (or (bare-number? x2) (clojure.core/< (:tag x2) (:tag x1))))
-      (value-with-derivative (:tag x1)
+      (and (map? x1) (map? x3) (= (::tag x1) (::tag x3)) (or (bare-number? x2) (clojure.core/< (::tag x2) (::tag x1))))
+      (value-with-derivative (::tag x1)
                              (new-f (:value x1) x2 (:value x3))
                              (+ (* (df-dx1 (:value x1) x2 (:value x3)) (:derivative x1))
                                 (* (df-dx3 (:value x1) x2 (:value x3)) (:derivative x3))))
 
-      (and (map? x2) (map? x3) (= (:tag x2) (:tag x3)) (or (bare-number? x1) (clojure.core/< (:tag x1) (:tag x2))))
-      (value-with-derivative (:tag x2)
+      (and (map? x2) (map? x3) (= (::tag x2) (::tag x3)) (or (bare-number? x1) (clojure.core/< (::tag x1) (::tag x2))))
+      (value-with-derivative (::tag x2)
                              (new-f x1 (:value x2) (:value x3))
                              (+ (* (df-dx2 x1 (:value x2) (:value x3)) (:derivative x2))
                                 (* (df-dx3 x1 (:value x2) (:value x3)) (:derivative x3))))
 
-      (and (map? x1) (map? x2) (map? x3) (= (:tag x1) (:tag x2) (:tag x3)))
-      (value-with-derivative (:tag x2)
+      (and (map? x1) (map? x2) (map? x3) (= (::tag x1) (::tag x2) (::tag x3)))
+      (value-with-derivative (::tag x2)
                              (new-f (:value x1) (:value x2) (:value x3))
                              (+ (* (df-dx1 (:value x1) (:value x2) (:value x3)) (:derivative x1))
                                 (* (df-dx2 (:value x1) (:value x2) (:value x3)) (:derivative x2))
@@ -236,12 +236,12 @@
   (let [y-forward (f (apply-2 (fn [x x-deriv] (value-with-derivative @e x x-deriv)) x x-deriv))]
     (swap! e dec)
     [(apply-1 (fn [y-forward]
-                (if (or (not (map? y-forward)) (clojure.core/< (:tag y-forward) @e))
+                (if (or (not (map? y-forward)) (clojure.core/< (::tag y-forward) @e))
                   y-forward
                   (:value y-forward)))
               y-forward)
      (apply-1 (fn [y-forward]
-                (if (or (not (map? y-forward)) (clojure.core/< (:tag y-forward) @e))
+                (if (or (not (map? y-forward)) (clojure.core/< (::tag y-forward) @e))
                   0
                   (:derivative y-forward)))
               y-forward)]))

--- a/src/metaprob/autodiff.cljc
+++ b/src/metaprob/autodiff.cljc
@@ -262,15 +262,20 @@
 (defn forward-mode [apply-2 apply-1 f x x-deriv]
   ;; Based on R6RS-ad, thus doesn't support tangent vector mode
   (swap! e inc)
-  (let [y-forward (f (apply-2 (fn [x x-deriv] (value-with-derivative @e x x-deriv)) x x-deriv))]
+  (let [y-forward (f (apply-2
+                       (fn [x x-deriv] (value-with-derivative @e x x-deriv))
+                       x
+                       x-deriv))]
     (swap! e dec)
     [(apply-1 (fn [y-forward]
-                (if (or (not (map? y-forward)) (clojure.core/< (::tag y-forward) @e))
+                (if (or (not (map? y-forward))
+                        (clojure.core/< (::tag y-forward) @e))
                   y-forward
                   (:value y-forward)))
               y-forward)
      (apply-1 (fn [y-forward]
-                (if (or (not (map? y-forward)) (clojure.core/< (::tag y-forward) @e))
+                (if (or (not (map? y-forward))
+                        (clojure.core/< (::tag y-forward) @e))
                   0
                   (:derivative y-forward)))
               y-forward)]))

--- a/src/metaprob/autodiff.cljc
+++ b/src/metaprob/autodiff.cljc
@@ -233,7 +233,7 @@
 
 
 (def tanh (lift-real->real #(Math/tanh %)
-                           (fn [x] (- 1 (#(* % %) (tanh x))))))
+                           (fn [x] (/ (#(* % %) (cosh x))))))
 
 (def == (lift-real-n->boolean clojure.core/==))
 

--- a/src/metaprob/autodiff.cljc
+++ b/src/metaprob/autodiff.cljc
@@ -161,7 +161,7 @@
 
 (defn shallow-unnest-value [x]
   "Return the `value` field. Acts as the identity if the argument is not a map."
-  (if (map? x) (:value x) x)
+  (if (map? x) (:value x) x))
 
 
 (defn lift-real-n->boolean [f]

--- a/src/metaprob/autodiff.cljc
+++ b/src/metaprob/autodiff.cljc
@@ -9,7 +9,7 @@
 
 (declare * + - /)
 
-(def non-dual? clojure.core/number?)
+(def bare-number? clojure.core/number?)
 
 ;; Take a unary operation f on numbers
 ;; and lift it to work with dual numbers.
@@ -19,7 +19,7 @@
 (defn lift-real->real
   [f df-dx]
   (fn new-f [x]
-    (if (non-dual? x)
+    (if (bare-number? x)
       (f x)
       (make-dual-number (:tag x)
                         (new-f (:value x))
@@ -32,14 +32,14 @@
   [f df-dx1 df-dx2]
   (fn new-f [x1 x2]
     (cond
-      (and (non-dual? x1) (non-dual? x2))
+      (and (bare-number? x1) (bare-number? x2))
       (f x1 x2)
-      (or (and (map? x1) (non-dual? x2))
+      (or (and (map? x1) (bare-number? x2))
           (and (map? x1) (map? x2) (clojure.core/> (:tag x1) (:tag x2))))
       (make-dual-number (:tag x1)
                         (new-f (:value x1) x2)
                         (* (df-dx1 (:value x1) x2) (:derivative x1)))
-      (or (and (non-dual? x1) (map? x2))
+      (or (and (bare-number? x1) (map? x2))
           (and (map? x1) (map? x2) (clojure.core/< (:tag x1) (:tag x2))))
       (make-dual-number (:tag x2)
                         (new-f x1 (:value x2))
@@ -54,43 +54,43 @@
   [f df-dx1 df-dx2 df-dx3]
   (fn new-f [x1 x2 x3]
     (cond
-      (and (non-dual? x1) (non-dual? x2) (non-dual? x3))
+      (and (bare-number? x1) (bare-number? x2) (bare-number? x3))
       (f x1 x2 x3)
 
       (and (map? x1)
-           (or (non-dual? x2)(clojure.core/< (:tag x2) (:tag x1)))
-           (or (non-dual? x3) (clojure.core/< (:tag x3) (:tag x1))))
+           (or (bare-number? x2)(clojure.core/< (:tag x2) (:tag x1)))
+           (or (bare-number? x3) (clojure.core/< (:tag x3) (:tag x1))))
       (make-dual-number (:tag x1)
                         (new-f (:value x1) x2 x3)
                         (* (df-dx1 (:value x1) x2 x3) (:derivative x1)))
 
       (and (map? x2)
-           (or (non-dual? x1) (clojure.core/< (:tag x1) (:tag x2)))
-           (or (non-dual? x3) (clojure.core/< (:tag x3) (:tag x2))))
+           (or (bare-number? x1) (clojure.core/< (:tag x1) (:tag x2)))
+           (or (bare-number? x3) (clojure.core/< (:tag x3) (:tag x2))))
       (make-dual-number (:tag x2)
                         (new-f x1 (:value x2) x3)
                         (* (df-dx2 x1 (:value x2) x3) (:derivative x2)))
 
       (and (map? x3)
-           (or (non-dual? x1) (clojure.core/< (:tag x1) (:tag x3)))
-           (or (non-dual? x2) (clojure.core/< (:tag x2) (:tag x3))))
+           (or (bare-number? x1) (clojure.core/< (:tag x1) (:tag x3)))
+           (or (bare-number? x2) (clojure.core/< (:tag x2) (:tag x3))))
       (make-dual-number (:tag x3)
                         (new-f x1 x2 (:value x3))
                         (* (df-dx3 x1 x2 (:value x3)) (:derivative x3)))
 
-      (and (map? x1) (map? x2) (= (:tag x1) (:tag x2)) (or (non-dual? x3) (clojure.core/< (:tag x3) (:tag x1))))
+      (and (map? x1) (map? x2) (= (:tag x1) (:tag x2)) (or (bare-number? x3) (clojure.core/< (:tag x3) (:tag x1))))
       (make-dual-number (:tag x1)
                         (new-f (:value x1) (:value x2) x3)
                         (+ (* (df-dx1 (:value x1) (:value x2) x3) (:derivative x1))
                            (* (df-dx2 (:value x1) (:value x2) x3) (:derivative x2))))
 
-      (and (map? x1) (map? x3) (= (:tag x1) (:tag x3)) (or (non-dual? x2) (clojure.core/< (:tag x2) (:tag x1))))
+      (and (map? x1) (map? x3) (= (:tag x1) (:tag x3)) (or (bare-number? x2) (clojure.core/< (:tag x2) (:tag x1))))
       (make-dual-number (:tag x1)
                         (new-f (:value x1) x2 (:value x3))
                         (+ (* (df-dx1 (:value x1) x2 (:value x3)) (:derivative x1))
                            (* (df-dx3 (:value x1) x2 (:value x3)) (:derivative x3))))
 
-      (and (map? x2) (map? x3) (= (:tag x2) (:tag x3)) (or (non-dual? x1) (clojure.core/< (:tag x1) (:tag x2))))
+      (and (map? x2) (map? x3) (= (:tag x2) (:tag x3)) (or (bare-number? x1) (clojure.core/< (:tag x1) (:tag x2))))
       (make-dual-number (:tag x2)
                         (new-f x1 (:value x2) (:value x3))
                         (+ (* (df-dx2 x1 (:value x2) (:value x3)) (:derivative x2))
@@ -118,7 +118,7 @@
           :else (reduce (lift-real*real->real f df-dx1 df-dx2) xs))))
 
 (defn value [x]
-  (if (non-dual? x) x (:value x)))
+  (if (bare-number? x) x (:value x)))
 
 
 (defn lift-real-n->boolean [f]

--- a/src/metaprob/autodiff.cljc
+++ b/src/metaprob/autodiff.cljc
@@ -45,10 +45,21 @@
                              (new-f (:value x))
                              (* (df-dx (:value x)) (:derivative x))))))
 
-;; Lift a binary operation on numbers to work
-;; with dual numbers. We have to consider several
-;; cases here.
 (defn lift-real*real->real
+  "Like `lift-real->real`, but here the function `f` is a binary operation.
+
+  The argument `df-dx1` is a function that computes the partial derivative of
+  `(f x1 x2)` with respect to `x1`.  It takes two arguments, each of which may
+  be either a bare number or a `value-with-derivative`; these arguments
+  identify the point  at which to evaluate the derivative (often denoted `(x1,
+  x2)` in math notation, though this is a name collision).
+
+  Similarly, `df-dx2` computes the partial derivative of `(f x1 x2)` with
+  respect to `x2`.
+  
+  The returned function accepts either a bare number or a
+  `value-with-derivative` for each of its arguments, and produces an output...
+  TODO(bzinberg) what does it produce."
   [f df-dx1 df-dx2]
   (fn new-f [x1 x2]
     (cond

--- a/src/metaprob/autodiff.cljc
+++ b/src/metaprob/autodiff.cljc
@@ -213,7 +213,7 @@
                           (fn [x] (- (sin x)))))
 
 (def tan (lift-real->real #(Math/tan %)
-                          (fn [x] (+ 1 (#(* % %) (cos x))))))
+                          (fn [x] (/ 1 (#(* % %) (cos x))))))
 
 (def asin (lift-real->real #(Math/asin %)
                            (fn [x] (/ 1 (sqrt (- 1 (* x x)))))))

--- a/src/metaprob/autodiff.cljc
+++ b/src/metaprob/autodiff.cljc
@@ -213,13 +213,13 @@
                           (fn [x] (- (sin x)))))
 
 (def tan (lift-real->real #(Math/tan %)
-                          (fn [x] (+ 1 (** (cos x) 2)))))
+                          (fn [x] (+ 1 (#(* % %) (cos x))))))
 
 (def asin (lift-real->real #(Math/asin %)
-                           (fn [x] (/ 1 (sqrt (- 1 (** x 2)))))))
+                           (fn [x] (/ 1 (sqrt (- 1 (* x x)))))))
 
 (def acos (lift-real->real #(Math/acos %)
-                           (fn [x] (- (/ 1 (sqrt (- 1 (** x 2))))))))
+                           (fn [x] (- (/ 1 (sqrt (- 1 (* x x))))))))
 
 (def atan (lift-real->real #(Math/atan %)
                            (fn [x] (/ 1 (+ 1 (* x x))))))
@@ -233,7 +233,7 @@
 
 
 (def tanh (lift-real->real #(Math/tanh %)
-                           (fn [x] (- 1 (** (tanh x) 2)))))
+                           (fn [x] (- 1 (#(* % %) (tanh x))))))
 
 (def == (lift-real-n->boolean clojure.core/==))
 

--- a/src/metaprob/autodiff.cljc
+++ b/src/metaprob/autodiff.cljc
@@ -213,7 +213,7 @@
                           (fn [x] (- (sin x)))))
 
 (def tan (lift-real->real #(Math/tan %)
-                          (fn [x] (+ 1 (** (tan x) 2)))))
+                          (fn [x] (+ 1 (** (cos x) 2)))))
 
 (def asin (lift-real->real #(Math/asin %)
                            (fn [x] (/ 1 (sqrt (- 1 (** x 2)))))))

--- a/src/metaprob/autodiff.cljc
+++ b/src/metaprob/autodiff.cljc
@@ -1,0 +1,251 @@
+(ns metaprob.autodiff
+  (:refer-clojure :exclude [+ * - / == < > <= >= zero? number? pos? neg?]))
+
+;; Dual numbers represent computations dependent on a value with respect to which we are differentiating.
+;; dual contains the current derivative; primal contains the current value; and tag is a special tag
+;; that helps distinguish between multiple "levels" of nested differentiations.
+(defn make-dual-number [tag primal dual]
+  {:tag tag :primal primal :dual dual})
+
+(declare * + - /)
+
+(def non-dual? clojure.core/number?)
+
+;; Take a unary operation f on numbers
+;; and lift it to work with dual numbers.
+;; Note that df-dx should itself be a lifted
+;; function for computing the derivative of f
+;; at a point.
+(defn lift-real->real
+  [f df-dx]
+  (fn new-f [x]
+    (if (map? x)
+      (make-dual-number (:tag x)
+                        (new-f (:primal x))
+                        (* (df-dx (:primal x)) (:dual x)))
+      (f x))))
+
+;; Lift a binary operation on numbers to work
+;; with dual numbers. We have to consider several
+;; cases here.
+(defn lift-real*real->real
+  [f df-dx1 df-dx2]
+  (fn new-f [x1 x2]
+    (cond
+      (and (non-dual? x1) (non-dual? x2))
+      (f x1 x2)
+      (or (and (map? x1) (non-dual? x2))
+          (and (map? x1) (map? x2) (clojure.core/> (:tag x1) (:tag x2))))
+      (make-dual-number (:tag x1)
+                        (new-f (:primal x1) x2)
+                        (* (df-dx1 (:primal x1) x2) (:dual x1)))
+      (or (and (non-dual? x1) (map? x2))
+          (and (map? x1) (map? x2) (clojure.core/< (:tag x1) (:tag x2))))
+      (make-dual-number (:tag x2)
+                        (new-f x1 (:primal x2))
+                        (* (df-dx2 x1 (:primal x2)) (:dual x2)))
+      (and (map? x1) (map? x2) (= (:tag x1) (:tag x2)))
+      (make-dual-number (:tag x1)
+                        (new-f (:primal x1) (:primal x2))
+                        (+ (* (df-dx1 (:primal x1) (:primal x2)) (:dual x1))
+                           (* (df-dx2 (:primal x1) (:primal x2)) (:dual x2)))))))
+
+(defn lift-real*real*real->real
+  [f df-dx1 df-dx2 df-dx3]
+  (fn new-f [x1 x2 x3]
+    (cond
+      (and (non-dual? x1) (non-dual? x2) (non-dual? x3))
+      (f x1 x2 x3)
+
+      (and (map? x1)
+           (or (non-dual? x2)(clojure.core/< (:tag x2) (:tag x1)))
+           (or (non-dual? x3) (clojure.core/< (:tag x3) (:tag x1))))
+      (make-dual-number (:tag x1)
+                        (new-f (:primal x1) x2 x3)
+                        (* (df-dx1 (:primal x1) x2 x3) (:dual x1)))
+
+      (and (map? x2)
+           (or (non-dual? x1) (clojure.core/< (:tag x1) (:tag x2)))
+           (or (non-dual? x3) (clojure.core/< (:tag x3) (:tag x2))))
+      (make-dual-number (:tag x2)
+                        (new-f x1 (:primal x2) x3)
+                        (* (df-dx2 x1 (:primal x2) x3) (:dual x2)))
+
+      (and (map? x3)
+           (or (non-dual? x1) (clojure.core/< (:tag x1) (:tag x3)))
+           (or (non-dual? x2) (clojure.core/< (:tag x2) (:tag x3))))
+      (make-dual-number (:tag x3)
+                        (new-f x1 x2 (:primal x3))
+                        (* (df-dx3 x1 x2 (:primal x3)) (:dual x3)))
+
+      (and (map? x1) (map? x2) (= (:tag x1) (:tag x2)) (or (non-dual? x3) (clojure.core/< (:tag x3) (:tag x1))))
+      (make-dual-number (:tag x1)
+                        (new-f (:primal x1) (:primal x2) x3)
+                        (+ (* (df-dx1 (:primal x1) (:primal x2) x3) (:dual x1))
+                           (* (df-dx2 (:primal x1) (:primal x2) x3) (:dual x2))))
+
+      (and (map? x1) (map? x3) (= (:tag x1) (:tag x3)) (or (non-dual? x2) (clojure.core/< (:tag x2) (:tag x1))))
+      (make-dual-number (:tag x1)
+                        (new-f (:primal x1) x2 (:primal x3))
+                        (+ (* (df-dx1 (:primal x1) x2 (:primal x3)) (:dual x1))
+                           (* (df-dx3 (:primal x1) x2 (:primal x3)) (:dual x3))))
+
+      (and (map? x2) (map? x3) (= (:tag x2) (:tag x3)) (or (non-dual? x1) (clojure.core/< (:tag x1) (:tag x2))))
+      (make-dual-number (:tag x2)
+                        (new-f x1 (:primal x2) (:primal x3))
+                        (+ (* (df-dx2 x1 (:primal x2) (:primal x3)) (:dual x2))
+                           (* (df-dx3 x1 (:primal x2) (:primal x3)) (:dual x3))))
+
+      (and (map? x1) (map? x2) (map? x3) (= (:tag x1) (:tag x2) (:tag x3)))
+      (make-dual-number (:tag x2)
+                        (new-f (:primal x1) (:primal x2) (:primal x3))
+                        (+ (* (df-dx1 (:primal x1) (:primal x2) (:primal x3)) (:dual x1))
+                           (* (df-dx2 (:primal x1) (:primal x2) (:primal x3)) (:dual x2))
+                           (* (df-dx3 (:primal x1) (:primal x2) (:primal x3)) (:dual x3)))))))
+
+;; For functions like + and *, which can take multiple arguments
+(defn lift-real-n->real [f df-dx1 df-dx2]
+  (fn [& xs]
+    (if (nil? xs)
+      (f)
+      (reduce (lift-real*real->real f df-dx1 df-dx2) xs))))
+
+;; For functions like - and /, where the first argument is special
+(defn lift-real-n+1->real [f df-dx df-dx1 df-dx2]
+  (fn [& xs]
+    (cond (empty? xs) (f)
+          (empty? (rest xs)) ((lift-real->real f df-dx) (first xs))
+          :else (reduce (lift-real*real->real f df-dx1 df-dx2) xs))))
+
+(defn primal [x]
+  (if (non-dual? x) x (:primal x)))
+
+
+(defn lift-real-n->boolean [f]
+  (fn [& xs] (apply f (map primal xs))))
+
+
+(def + (lift-real-n->real clojure.core/+
+                          (fn [x1 x2] 1)
+                          (fn [x1 x2] 1)))
+
+(def - (lift-real-n+1->real clojure.core/-
+                            (fn [x] -1)
+                            (fn [x1 x2] 1)
+                            (fn [x1 x2] -1)))
+
+(def * (lift-real-n->real clojure.core/*
+                          (fn [x1 x2] x2)
+                          (fn [x1 x2] x1)))
+
+(declare log)
+(def ** (lift-real*real->real #(Math/pow %1 %2)
+                              (fn [x1 x2] (* x2 (** x1 (- x2 1))))
+                              (fn [x1 x2] (* (log x1) (** x1 x2)))))
+
+(def / (lift-real-n+1->real clojure.core//
+                              (fn [x] (- (/ (Math/pow x 2))))
+                              (fn [x1 x2] (/ x2))
+                              (fn [x1 x2] (- (/ x1 (** x2 2))))))
+
+(def sqrt (lift-real->real #(Math/sqrt %)
+                           (fn [x] (/ 1 (* 2 (sqrt x))))))
+
+(def exp (lift-real->real #(Math/exp %)
+                          (fn [x] (exp x))))
+
+(def log (lift-real->real #(Math/log %)
+                          (fn [x] (/ x))))
+
+(def log1p (lift-real->real #(Math/log1p %)
+                            (fn [x] (/ (+ 1 x)))))
+
+(declare cos)
+(def sin (lift-real->real #(Math/sin %)
+                          (fn [x] (cos x))))
+
+(def cos (lift-real->real #(Math/cos %)
+                          (fn [x] (- (sin x)))))
+
+(def tan (lift-real->real #(Math/tan %)
+                          (fn [x] (+ 1 (** (tan x) 2)))))
+
+(def asin (lift-real->real #(Math/asin %)
+                           (fn [x] (/ 1 (sqrt (- 1 (** x 2)))))))
+
+(def acos (lift-real->real #(Math/acos %)
+                           (fn [x] (- (/ 1 (sqrt (- 1 (** x 2))))))))
+
+(def atan (lift-real->real #(Math/atan %)
+                           (fn [x] (/ 1 (+ 1 (* x x))))))
+
+(declare cosh)
+(def sinh (lift-real->real #(Math/sinh %)
+                           (fn [x] (cosh x))))
+
+(def cosh (lift-real->real #(Math/cosh %)
+                           (fn [x] (sinh x))))
+
+
+(def tanh (lift-real->real #(Math/tanh %)
+                           (fn [x] (- 1 (** (tanh x) 2)))))
+
+(def == (lift-real-n->boolean clojure.core/==))
+
+(def < (lift-real-n->boolean clojure.core/<))
+
+(def > (lift-real-n->boolean clojure.core/>))
+
+(def <= (lift-real-n->boolean clojure.core/<=))
+
+(def >= (lift-real-n->boolean clojure.core/>=))
+
+(def zero? (lift-real-n->boolean clojure.core/zero?))
+
+(def pos? (lift-real-n->boolean clojure.core/pos?))
+
+(def neg? (lift-real-n->boolean clojure.core/neg?))
+
+(def number? (lift-real-n->boolean clojure.core/number?))
+
+;; Q: Do we need abs, floor, ceil, min, max?
+
+(def e (atom 0))
+
+;; Helper function used by `diff` and `gradient-vector`.
+;; Returns [(f x) (df-dx x)]
+(defn forward-mode [map-independent map-dependent f x x-perturbation]
+  ;; Based on R6RS-ad, thus doesn't support tangent vector mode
+  (swap! e inc)
+  (let [y-forward (f (map-independent (fn [x x-dual] (make-dual-number @e x x-dual))
+                                      x
+                                      x-perturbation))]
+    (swap! e dec)
+    [(map-dependent (fn [y-forward]
+                      (if (or (not (map? y-forward))
+                              (clojure.core/< (:tag y-forward) @e))
+                        y-forward
+                        (:primal y-forward)))
+                    y-forward)
+     (map-dependent (fn [y-forward]
+                      (if (or (not (map? y-forward))
+                              (clojure.core/< (:tag y-forward) @e))
+                        0
+                        (:dual y-forward)))
+                    y-forward)]))
+
+;; Our "map" functions just apply `f`.
+(defn diff [f]
+  (fn [x]
+    (second (forward-mode (fn [f x x-dual] (f x x-dual))
+                          (fn [f y-forward] (f y-forward))
+                          f x 1))))
+
+;; To get a gradient, we differentiate w.r.t. each variable.
+;; Assumes f's argument is a vector of real numbers.
+(defn gradient [f]
+  (fn [x]
+    (doall (map (fn [i]
+           ((diff (fn [xi] (f (assoc x i xi))))
+             (nth x i)))
+         (range (count x))))))

--- a/src/metaprob/autodiff.cljc
+++ b/src/metaprob/autodiff.cljc
@@ -182,7 +182,9 @@
                           (fn [x1 x2] x1)))
 
 (declare log)
-(def ** (lift-real*real->real #(Math/pow %1 %2)
+(def **
+  "Power function, `pow(x1, x2) = x1**x2`. The base `x1` must be positive."
+  (lift-real*real->real #(Math/pow %1 %2)
                               (fn [x1 x2] (* x2 (** x1 (- x2 1))))
                               (fn [x1 x2] (* (log x1) (** x1 x2)))))
 

--- a/src/metaprob/distributions.cljc
+++ b/src/metaprob/distributions.cljc
@@ -1,6 +1,7 @@
 (ns metaprob.distributions
-  (:refer-clojure :exclude [apply map replicate reduce])
+  (:refer-clojure :exclude [apply map replicate reduce + - * / < == <= >= >])
   (:require [metaprob.prelude :as mp :refer [map make-primitive]]
+            [metaprob.autodiff :as ad]
             #?(:clj [incanter.distributions :as distributions])))
 
 (def exactly
@@ -11,51 +12,51 @@
 (def uniform
   (make-primitive
    (fn [a b] (mp/sample-uniform a b))
-   (fn [x [a b]] (if (<= a x b) (- (mp/log (- b a))) mp/negative-infinity))))
+   (fn [x [a b]] (if (ad/<= a x b) (ad/- (mp/log (ad/- b a))) mp/negative-infinity))))
 
 (def uniform-discrete
   (make-primitive
-   (fn [items] (nth items (Math/floor (* (mp/sample-uniform) (count items)))))
+   (fn [items] (nth items (Math/floor (ad/* (mp/sample-uniform) (count items)))))
    (fn [item [items]]
-     (- (mp/log (count (filter #(= % item) items)))
+     (ad/- (mp/log (count (filter #(= % item) items)))
         (mp/log (count items))))))
 
 (def flip
   (make-primitive
-   (fn [weight] (< (mp/sample-uniform) weight))
+   (fn [weight] (ad/< (mp/sample-uniform) weight))
    (fn [value [weight]]
      (if value
        (mp/log weight)
-       (mp/log1p (- weight))))))
+       (mp/log1p (ad/- weight))))))
 
 (defn normalize-numbers [nums]
-  (let [total (clojure.core/reduce + nums)] (map #(/ % total) nums)))
+  (let [total (clojure.core/reduce ad/+ nums)] (map #(ad// % total) nums)))
 
 (def categorical
   (make-primitive
    (fn [probs]
      (if (map? probs)
        (nth (keys probs) (categorical (normalize-numbers (vals probs)))) ;; TODO: normalization not needed here?
-       (let [total (clojure.core/reduce + probs)
-             r (* (mp/sample-uniform) total)]
+       (let [total (clojure.core/reduce ad/+ probs)
+             r (ad/* (mp/sample-uniform) total)]
          (loop [i 0, sum 0]
-           (if (< r (+ (nth probs i) sum)) i (recur (inc i) (+ (nth probs i) sum)))))))
+           (if (ad/< r (ad/+ (nth probs i) sum)) i (recur (inc i) (ad/+ (nth probs i) sum)))))))
    (fn [i [probs]]
      (if (map? probs)
-       (if (not (contains? probs i)) mp/negative-infinity (- (mp/log (get probs i)) (mp/log (clojure.core/reduce + (vals probs)))))
+       (if (not (contains? probs i)) mp/negative-infinity (ad/- (mp/log (get probs i)) (mp/log (clojure.core/reduce ad/+ (vals probs)))))
        (mp/log (nth probs i))))))
 
 (defn logsumexp [scores]
   (let [max-score (mp/apply max scores)
-        weights (map #(Math/exp (- % max-score)) scores)]
-    (+ (Math/log (clojure.core/reduce + weights)) max-score)))
+        weights (map #(mp/exp (ad/- % max-score)) scores)]
+    (ad/+ (mp/log (clojure.core/reduce ad/+ weights)) max-score)))
 
 (defn logmeanexp [scores]
-  (- (logsumexp scores) (mp/log (count scores))))
+  (ad/- (logsumexp scores) (mp/log (count scores))))
 
 (defn log-scores-to-probabilities [scores]
   (let [log-normalizer (logsumexp scores)]
-    (map #(Math/exp (- % log-normalizer)) scores)))
+    (map #(mp/exp (ad/- % log-normalizer)) scores)))
 
 
 (def log-categorical
@@ -70,15 +71,15 @@
            (if (map? scores) (into {} (clojure.core/map (fn [a b] [a b]) (keys scores) (log-scores-to-probabilities (vals scores))))
                (log-scores-to-probabilities scores))]
        (if (map? probs)
-         (if (not (contains? probs i)) mp/negative-infinity (- (mp/log (get probs i)) (mp/log (clojure.core/reduce + (vals probs)))))
+         (if (not (contains? probs i)) mp/negative-infinity (ad/- (mp/log (get probs i)) (mp/log (clojure.core/reduce ad/+ (vals probs)))))
          (mp/log (nth probs i)))))))
 
 
 (defn generate-gaussian [mu sigma]
-  (+ mu (* sigma (Math/sqrt (* -2 (Math/log (mp/sample-uniform)))) (Math/cos (* 2 Math/PI (mp/sample-uniform))))))
-(defn standard-gaussian-log-density [x] (* -0.5 (+ (Math/log (* 2 Math/PI)) (* x x))))
+  (ad/+ mu (ad/* sigma (mp/sqrt (ad/* -2 (mp/log (mp/sample-uniform)))) (mp/cos (ad/* 2 Math/PI (mp/sample-uniform))))))
+(defn standard-gaussian-log-density [x] (ad/* -0.5 (ad/+ (mp/log (ad/* 2 Math/PI)) (ad/* x x))))
 (defn score-gaussian [x [mu sigma]]
-  (- (standard-gaussian-log-density (/ (- x mu) sigma)) (Math/log sigma)))
+  (ad/- (standard-gaussian-log-density (ad// (ad/- x mu) sigma)) (mp/log sigma)))
 
 (def gaussian
   (make-primitive
@@ -87,25 +88,73 @@
 
 (def geometric
   (make-primitive
-   (fn [p] (loop [i 0] (if (flip p) (recur (+ i 1)) i)))
-   (fn [v [p]] (+ (mp/log1p (- p)) (* (mp/log p) v)))))
+   (fn [p] (loop [i 0] (if (flip p) (recur (inc i)) i)))
+   (fn [v [p]] (ad/+ (mp/log1p (ad/- p)) (ad/* (mp/log p) v)))))
 
-#?(:clj (def gamma
-          (make-primitive
-           (fn [shape scale]
-             (distributions/draw
-              (distributions/gamma-distribution shape scale)))
-           (fn [x [shape scale]]
-             (mp/log (distributions/pdf
-                   (distributions/gamma-distribution shape scale)
-                   x))))))
+;; This implementation comes from Anglican:
+;;
+(defn digamma
+  "digamma function psi(x): derivative of gammaln(x),
+  apparently bizarrely missing from all Clojure libraries.
+  Not yet implemented for negative values of x.
+  source: http://en.wikipedia.org/wiki/Digamma_function"
+  [x]
+  (assert (ad/>= x 0.0))
+  (if (ad/<= x 0.0)
+    (mp/log 0.0)
+    (let [partial-sum (if (ad/< x 1) (ad// -1. x) 0.0)
+          x (if (ad/< x 1) (ad/+ x 1.0) x)]
+      (ad/+ partial-sum
+         (ad/log x)
+         (ad// -1. (ad/* 2 x))
+         (ad// -1. (ad/* 12 (ad/** x 2)))
+         (ad// 1. (ad/* 120 (ad/** x 4)))
+         (ad// -1. (ad/* 252 (ad/** x 6)))
+         (ad// 1. (ad/* 240 (ad/** x 8)))
+         (ad// -5. (ad/* 660 (ad/** x 10)))
+         (ad// 691. (ad/* 32760 (ad/** x 12)))
+         (ad// -1. (ad/* 12 (ad/** x 14)))))))
 
-#?(:clj (def beta
-          (make-primitive
-           (fn [alpha beta]
-             (distributions/draw
-              (distributions/beta-distribution alpha beta)))
-           (fn [x [alpha beta]]
-             (mp/log (distributions/pdf
-                   (distributions/beta-distribution alpha beta)
-                   x))))))
+
+; Old: (log (distributions/pdf (distributions/beta-distribution alpha beta) x)))))
+
+
+#?(:clj
+   (def gamma
+     (mp/make-primitive
+       (fn [shape scale]
+         (distributions/draw (distributions/gamma-distribution shape scale)))
+       (let [f
+             (fn [x shape scale]
+               (mp/log (distributions/pdf (distributions/gamma-distribution shape scale) x)))
+             df-dx
+             (fn [x shape scale]
+               (ad/- (ad// (ad/- shape 1.) x) (ad// scale)))
+             df-dshape
+             (fn [x shape scale]
+               (ad/- (mp/log x) (mp/log scale) (digamma shape)))
+             df-dscale
+             (fn [x shape scale]
+               (ad/- (ad// x (mp/expt scale 2)) (ad// shape scale)))
+             differentiable-log-pdf
+             (ad/lift-real*real*real->real f df-dx df-dshape df-dscale)]
+         (fn [x [shape scale]]
+           (differentiable-log-pdf x shape scale))))))
+
+#?(:clj
+   (def beta
+     (mp/make-primitive
+       (fn [alpha beta]
+         (distributions/draw (distributions/beta-distribution alpha beta)))
+       (let
+         [f (fn [x alpha beta]
+              (mp/log (distributions/pdf (distributions/beta-distribution alpha beta) x)))
+          df-dx (fn [x alpha beta]
+                  (ad/- (ad// (ad/- alpha 1) x) (ad// (ad/- beta 1) (ad/- 1 x))))
+          df-dalpha (fn [x alpha beta]
+                      (ad/- (mp/log x) (ad/- (digamma alpha) (digamma (ad/+ alpha beta)))))
+          df-dbeta (fn [x alpha beta]
+                     (ad/- (mp/log1p (ad/- x)) (ad/- (digamma beta) (digamma (ad/+ alpha beta)))))
+          differentiable-log-pdf (ad/lift-real*real*real->real f df-dx df-dalpha df-dbeta)]
+         (fn [x [alpha beta]]
+           (differentiable-log-pdf x alpha beta))))))

--- a/src/metaprob/examples/aide.clj
+++ b/src/metaprob/examples/aide.clj
@@ -2,7 +2,7 @@
   (:refer-clojure :exclude [map replicate apply])
   (:require [metaprob.trace :refer :all]
             [metaprob.generative-functions :refer :all]
-            [metaprob.prelude :refer [map replicate expt]]
+            [metaprob.prelude :refer [map replicate expt infer-and-score]]
             [metaprob.distributions :refer :all]
             [clojure.pprint :refer [pprint]]
             [metaprob.inference :refer :all]))

--- a/src/metaprob/examples/curve_fitting.clj
+++ b/src/metaprob/examples/curve_fitting.clj
@@ -2,7 +2,7 @@
   (:refer-clojure :exclude [map replicate apply])
   (:require [metaprob.trace :refer :all]
             [metaprob.generative-functions :refer :all]
-            [metaprob.prelude :refer [map expt replicate]]
+            [metaprob.prelude :refer [map expt replicate infer-and-score]]
             [metaprob.distributions :refer :all]
             [clojure.pprint :refer [pprint]]
             [metaprob.inference :refer :all]))
@@ -112,4 +112,4 @@
 (defn -main []
   (pprint (last (run-mh xs ys-linear 200)))
   (pprint (last (run-mh xs ys-linear-outlier 300)))
-  (pprint (last (run-mh xs ys-quadratic 10000))))
+  (pprint (last (run-mh xs ys-quadratic 6000))))

--- a/src/metaprob/examples/earthquake.clj
+++ b/src/metaprob/examples/earthquake.clj
@@ -163,7 +163,7 @@
       (importance-resampling
         :model earthquake-bayesian-network
         :obesrvation-trace alarm-went-off
-        n-particles))))
+        :n-particles n-particles))))
 
 
 ;; TBD: importance sampling
@@ -200,3 +200,6 @@
 
     (earthquake-histogram "bayesnet samples from importance sampling with 20 particles"
                           (map trace-to-binary (eq-importance-assay 20 n-samples)))))
+
+(defn -main []
+  (demo-earthquake))

--- a/src/metaprob/examples/multimixture_dsl.clj
+++ b/src/metaprob/examples/multimixture_dsl.clj
@@ -2,7 +2,7 @@
   (:refer-clojure :exclude [map replicate apply])
   (:require [metaprob.trace :refer :all]
             [metaprob.generative-functions :refer :all]
-            [metaprob.prelude :refer [map log apply]]
+            [metaprob.prelude :refer [map log apply infer-and-score]]
             [metaprob.distributions :refer :all]
             [clojure.pprint :refer [pprint]]
             [metaprob.inference :refer :all]))

--- a/src/metaprob/examples/variational_on_gaussians.clj
+++ b/src/metaprob/examples/variational_on_gaussians.clj
@@ -48,7 +48,7 @@
       y)))
 
 ; Guide
-(defn normal-normal-predicter
+(defn normal-normal-predictor
   [[a b sigma2]]
   (gen [obs]
     (let [y (trace/trace-value obs "y")]
@@ -57,7 +57,7 @@
           (ad/sqrt sigma2)))))
 
 ;; Amortized inference: minimize KL(model || guide)
-(defn train-normal-normal-predicter-amortized []
+(defn train-normal-normal-predictor-amortized []
   (let [final-params
         (time
           (last
@@ -66,17 +66,17 @@
                     (fn [params]
                       (infer/train-amortized-inference-program
                         :model normal-normal
-                        :guide normal-normal-predicter
+                        :guide normal-normal-predictor
                         :observation-addresses ["y"]
                         :step-size 0.01
                         :batch-size 10
                         :current-params params))
                     [1 1 1]))))]
     (println final-params)
-    (normal-normal-predicter final-params)))
+    (normal-normal-predictor final-params)))
 
 ;; Variational inference: minimize KL(guide || model)
-(defn train-normal-normal-predicter-variational []
+(defn train-normal-normal-predictor-variational []
   (let [final-params
         (time
           (last
@@ -85,16 +85,16 @@
                     (fn [params]
                       (infer/reparam-variational-inference
                         :model normal-normal
-                        :guide normal-normal-predicter
+                        :guide normal-normal-predictor
                         :observation-addresses ["y"]
                         :step-size 0.01
                         :current-params params))
                     [1 1 1]))))]
     (println final-params)
-    (normal-normal-predicter final-params)))
+    (normal-normal-predictor final-params)))
 
 ;; Score Variational inference: minimize KL(guide || model)
-(defn train-normal-normal-predicter-variational-score []
+(defn train-normal-normal-predictor-variational-score []
   (let [final-params
         (time
           (last
@@ -103,19 +103,19 @@
                     (fn [params]
                       (infer/score-func-variational-inference
                         :model normal-normal
-                        :guide normal-normal-predicter
+                        :guide normal-normal-predictor
                         :observation-addresses ["y"]
                         :step-size 0.0005
                         :current-params params))
                     [1 1 1]))))]
     (println final-params)
-    (normal-normal-predicter final-params)))
+    (normal-normal-predictor final-params)))
 
 
 (defn normal-normal-demo []
-  (train-normal-normal-predicter-amortized)
-  (train-normal-normal-predicter-variational)
-  (train-normal-normal-predicter-variational-score))
+  (train-normal-normal-predictor-amortized)
+  (train-normal-normal-predictor-variational)
+  (train-normal-normal-predictor-variational-score))
 
 
 (def mixture-model
@@ -125,13 +125,13 @@
                  (ad/+ (ad/* 0.5 (ad/exp (dist/score-gaussian x [-5 1])))
                        (ad/* 0.5 (ad/exp (dist/score-gaussian x [5 1]))))))))
 
-(defn mixture-predicter
+(defn mixture-predictor
   [[mu sigma]]
   (gen [obs]
     (at '() dist/gaussian mu sigma)))
 
 ;; Amortized inference: minimize KL(model || guide)
-(defn train-mixture-predicter-amortized []
+(defn train-mixture-predictor-amortized []
   (let [final-params
         (time
           (last
@@ -140,7 +140,7 @@
                     (fn [params]
                       (infer/train-amortized-inference-program
                         :model mixture-model
-                        :guide mixture-predicter
+                        :guide mixture-predictor
                         :observation-addresses []
                         :step-size 0.01
                         :batch-size 10
@@ -148,10 +148,10 @@
                     [2 1]))))]
     (println final-params)
 
-    (mixture-predicter final-params)))
+    (mixture-predictor final-params)))
 
 ;; Variational inference: minimize KL(guide || model)
-(defn train-mixture-predicter-variational []
+(defn train-mixture-predictor-variational []
   (let [final-params
         (time
           (last
@@ -160,17 +160,17 @@
                     (fn [params]
                       (infer/reparam-variational-inference
                         :model mixture-model
-                        :guide mixture-predicter
+                        :guide mixture-predictor
                         :observation-addresses []
                         :step-size 0.05
                         :current-params params))
                     [0 1]))))]
     (println final-params)
-    (mixture-predicter final-params)))
+    (mixture-predictor final-params)))
 
 
 ;; Variational inference: minimize KL(guide || model)
-(defn train-mixture-predicter-variational-score []
+(defn train-mixture-predictor-variational-score []
   (let [final-params
         (time
           (last
@@ -179,19 +179,19 @@
                     (fn [params]
                       (infer/score-func-variational-inference
                         :model mixture-model
-                        :guide mixture-predicter
+                        :guide mixture-predictor
                         :observation-addresses []
                         :step-size 0.05
                         :current-params params))
                     [0 1]))))]
     (println final-params)
-    (mixture-predicter final-params)))
+    (mixture-predictor final-params)))
 
 
 (defn mixture-demo []
-  (train-mixture-predicter-amortized)
-  (train-mixture-predicter-variational)
-  (train-mixture-predicter-variational-score))
+  (train-mixture-predictor-amortized)
+  (train-mixture-predictor-variational)
+  (train-mixture-predictor-variational-score))
 
 
 (defn -main []

--- a/src/metaprob/examples/variational_on_gaussians.clj
+++ b/src/metaprob/examples/variational_on_gaussians.clj
@@ -66,7 +66,7 @@
                     (fn [params]
                       (infer/train-amortized-inference-program
                         :model normal-normal
-                        :inference-program normal-normal-predicter
+                        :guide normal-normal-predicter
                         :observation-addresses ["y"]
                         :step-size 0.01
                         :batch-size 10
@@ -140,7 +140,7 @@
                     (fn [params]
                       (infer/train-amortized-inference-program
                         :model mixture-model
-                        :inference-program mixture-predicter
+                        :guide mixture-predicter
                         :observation-addresses []
                         :step-size 0.01
                         :batch-size 10

--- a/src/metaprob/examples/variational_on_gaussians.clj
+++ b/src/metaprob/examples/variational_on_gaussians.clj
@@ -1,0 +1,203 @@
+(ns metaprob.examples.variational-on-gaussians
+  (:require [metaprob.inference :as infer]
+            [clojure.pprint :refer [pprint]]
+            [metaprob.distributions :as dist]
+            [metaprob.prelude :as mp]
+            [metaprob.trace :as trace]
+            [metaprob.generative-functions :refer [at gen let-traced]]
+            [metaprob.autodiff :as ad]))
+
+(def beta-binomial
+  (gen [n]
+    (let-traced [p1 (dist/beta 1 1)
+                 p2 (dist/beta 1 1)]
+      (doall (map #(at % dist/flip (if (at `("which-p" ~%) dist/flip 0.5) p1 p2)) (range n))))))
+
+(defn make-observation-trace [l]
+  (first (reduce (fn [[tr i] x] [(trace/trace-set-value tr i x) (inc i)]) [{} 0] l)))
+
+(defn initial-trace [l]
+  (trace/trace-clear-subtrace
+    ((mp/infer-and-score :procedure beta-binomial
+                         :inputs [(count l)]
+                         :observation-trace (make-observation-trace l)) 1)
+    "which-p"))
+
+
+(defn map-optimize-demo []
+  (pprint
+    (let [tr
+          (time
+            (last
+              (take 200
+                (iterate
+                  (infer/map-optimize-step
+                    :model beta-binomial
+                    :inputs [200]
+                    :step-size 0.0001
+                    :addresses '("p1" "p2"))
+                  (initial-trace (vec (concat (repeat 100 true) (repeat 100 false))))))))]
+  [(trace/trace-value tr "p1") (trace/trace-value tr "p2")])))
+
+
+; Model
+(def normal-normal
+  (gen []
+    (let-traced [x (dist/gaussian 0 1)
+                 y (dist/gaussian x 1)]
+      y)))
+
+; Guide
+(defn normal-normal-predicter
+  [[a b sigma2]]
+  (gen [obs]
+    (let [y (trace/trace-value obs "y")]
+      (at "x" dist/gaussian
+          (ad/+ b (ad/* a y))
+          (ad/sqrt sigma2)))))
+
+;; Amortized inference: minimize KL(model || guide)
+(defn train-normal-normal-predicter-amortized []
+  (let [final-params
+        (time
+          (last
+            (take 5000
+                  (iterate
+                    (fn [params]
+                      (infer/train-amortized-inference-program
+                        :model normal-normal
+                        :inference-program normal-normal-predicter
+                        :observation-addresses ["y"]
+                        :prediction-addresses ["x"]
+                        :step-size 0.01
+                        :batch-size 10
+                        :current-params params))
+                    [1 1 1]))))]
+    (println final-params)
+    (normal-normal-predicter final-params)))
+
+;; Variational inference: minimize KL(guide || model)
+(defn train-normal-normal-predicter-variational []
+  (let [final-params
+        (time
+          (last
+            (take 5000
+                  (iterate
+                    (fn [params]
+                      (infer/reparam-variational-inference
+                        :model normal-normal
+                        :guide normal-normal-predicter
+                        :observation-addresses ["y"]
+                        :step-size 0.01
+                        :current-params params))
+                    [1 1 1]))))]
+    (println final-params)
+    (normal-normal-predicter final-params)))
+
+;; Score Variational inference: minimize KL(guide || model)
+(defn train-normal-normal-predicter-variational-score []
+  (let [final-params
+        (time
+          (last
+            (take 10000
+                  (iterate
+                    (fn [params]
+                      (infer/score-func-variational-inference
+                        :model normal-normal
+                        :guide normal-normal-predicter
+                        :observation-addresses ["y"]
+                        :step-size 0.0005
+                        :current-params params))
+                    [1 1 1]))))]
+    (println final-params)
+    (normal-normal-predicter final-params)))
+
+
+(defn normal-normal-demo []
+  (train-normal-normal-predicter-amortized)
+  (train-normal-normal-predicter-variational)
+  (train-normal-normal-predicter-variational-score))
+
+
+(def mixture-model
+  (mp/make-primitive
+    (fn [] (if (dist/flip 0.5) (dist/gaussian -5 1) (dist/gaussian 5 1)))
+    (fn [x []] (ad/log
+                 (ad/+ (ad/* 0.5 (ad/exp (dist/score-gaussian x [-5 1])))
+                       (ad/* 0.5 (ad/exp (dist/score-gaussian x [5 1]))))))))
+
+(defn mixture-predicter
+  [[mu sigma]]
+  (gen [obs]
+    (at '() dist/gaussian mu sigma)))
+
+;; Amortized inference: minimize KL(model || guide)
+(defn train-mixture-predicter-amortized []
+  (let [final-params
+        (time
+          (last
+            (take 6000
+                  (iterate
+                    (fn [params]
+                      (infer/train-amortized-inference-program
+                        :model mixture-model
+                        :inference-program mixture-predicter
+                        :observation-addresses []
+                        :prediction-addresses ['()]
+                        :step-size 0.01
+                        :batch-size 10
+                        :current-params params))
+                    [2 1]))))]
+    (println final-params)
+    (mixture-predicter final-params)))
+
+;; Variational inference: minimize KL(guide || model)
+(defn train-mixture-predicter-variational []
+  (let [final-params
+        (time
+          (last
+            (take 30000
+                  (iterate
+                    (fn [params]
+                      (infer/reparam-variational-inference
+                        :model mixture-model
+                        :guide mixture-predicter
+                        :observation-addresses []
+                        :step-size 0.05
+                        :current-params params))
+                    [0 1]))))]
+    (println final-params)
+    (mixture-predicter final-params)))
+
+
+;; Variational inference: minimize KL(guide || model)
+(defn train-mixture-predicter-variational-score []
+  (let [final-params
+        (time
+          (last
+            (take 30000
+                  (iterate
+                    (fn [params]
+                      (infer/score-func-variational-inference
+                        :model mixture-model
+                        :guide mixture-predicter
+                        :observation-addresses []
+                        :step-size 0.05
+                        :current-params params))
+                    [0 1]))))]
+    (println final-params)
+    (mixture-predicter final-params)))
+
+
+(defn mixture-demo []
+  (train-mixture-predicter-amortized)
+  (train-mixture-predicter-variational)
+  (train-mixture-predicter-variational-score))
+
+
+(defn -main []
+  (map-optimize-demo)
+  (normal-normal-demo)
+  (mixture-demo))
+
+;; => {"p" {:value 0.3594875896}, "y" {:value false}}

--- a/src/metaprob/examples/variational_on_gaussians.clj
+++ b/src/metaprob/examples/variational_on_gaussians.clj
@@ -68,7 +68,6 @@
                         :model normal-normal
                         :inference-program normal-normal-predicter
                         :observation-addresses ["y"]
-                        :prediction-addresses ["x"]
                         :step-size 0.01
                         :batch-size 10
                         :current-params params))
@@ -143,12 +142,12 @@
                         :model mixture-model
                         :inference-program mixture-predicter
                         :observation-addresses []
-                        :prediction-addresses ['()]
                         :step-size 0.01
                         :batch-size 10
                         :current-params params))
                     [2 1]))))]
     (println final-params)
+
     (mixture-predicter final-params)))
 
 ;; Variational inference: minimize KL(guide || model)

--- a/src/metaprob/generative_functions.cljc
+++ b/src/metaprob/generative_functions.cljc
@@ -2,6 +2,7 @@
   #?(:cljs (:require-macros [metaprob.generative-functions :refer [gen]]))
   (:require #?(:cljs [cljs.analyzer :as ana])
             [metaprob.code-handlers :as code]
+            [metaprob.autodiff :as ad]
             [metaprob.trace :as trace]))
 
 (defn at [& args] (assert false "Cannot invoke at outside of a (gen ...) form."))
@@ -44,7 +45,7 @@
                   apply-at-impl
                   (fn [addr gf args]
                     (let [[v tr s] (apply-at addr (make-constrained-generator gf (trace/maybe-subtrace observations addr)) args)]
-                      (swap! score + s)
+                      (swap! score ad/+ s)
                       (swap! trace trace/merge-subtrace addr tr)
                       v))
                   at-impl

--- a/src/metaprob/inference.cljc
+++ b/src/metaprob/inference.cljc
@@ -409,9 +409,6 @@
              ;; as input to the inference program.
              observation-addresses
              ;; Addresses of the model _and_ inference program that are the prediction targets.
-             prediction-addresses
-             ;; Step size alpha is the multiplier of the gradient estimate used in stochastic
-             ;; gradient descent
              step-size
              ;; How many samples to take in forming a gradient estimate
              batch-size]
@@ -422,11 +419,9 @@
   (let [model-traces
         (take batch-size (repeatedly #(nth (mp/infer-and-score :procedure model) 1)))
 
-        observeds
-        (map #(first (trace/partition-trace % observation-addresses)) model-traces)
-
-        to-predicts
-        (map #(first (trace/partition-trace % prediction-addresses)) model-traces)
+        [observeds to-predicts]
+        ((juxt (partial map first) (partial map second))
+          (map #(trace/partition-trace % observation-addresses) model-traces))
 
         avg
         (fn [l] (ad// (reduce ad/+ l) (count l)))

--- a/src/metaprob/inference.cljc
+++ b/src/metaprob/inference.cljc
@@ -180,17 +180,20 @@
   (fn [current-trace]
     (let [[_ _ current-trace-score]               ;; Evaluate log p(t)
           (mp/infer-and-score :procedure model
-                               :inputs inputs
-                               :observation-trace current-trace)
+                              :inputs inputs
+                              :observation-trace current-trace)
 
-          [proposed-trace all-proposer-choices _] ;; Sample t' ~ q(• <- t)
+          [_ all-proposer-choices _] ;; Sample t' ~ q(• <- t)
           (mp/infer-and-score :procedure proposal
-                               :inputs [current-trace])
+                              :inputs [current-trace])
 
-          [_ _ new-trace-score]                   ;; Evaluate log p(t')
+          [_ proposed-trace new-trace-score]                   ;; Evaluate log p(t')
           (mp/infer-and-score :procedure model
-                               :inputs inputs
-                               :observation-trace proposed-trace)
+                              :inputs inputs
+                              :observation-trace
+                              (trace/copy-addresses
+                                all-proposer-choices current-trace
+                                (trace/addresses-of all-proposer-choices)))
 
           [_ _ forward-proposal-score]            ;; Estimate log q(t' <- t)
           (mp/infer-and-score :procedure proposal

--- a/src/metaprob/inference.cljc
+++ b/src/metaprob/inference.cljc
@@ -353,7 +353,7 @@
 ;; gradient ascent step on the value at a certain trace address,
 ;; optimizing the log joint probability of the trace.
 (defn map-optimize-step
-  [& {:keys [model inputs step-size min-step-size max-step-size addresses]
+  [& {:keys [model inputs step-size addresses]
       :or {step-size 0.01 inputs []}}]
   (fn [current-trace]
     (let [score-choices

--- a/src/metaprob/inference.cljc
+++ b/src/metaprob/inference.cljc
@@ -468,7 +468,7 @@
                 (mp/infer-and-score :procedure (guide params)
                                     :inputs [observed])
 
-                ;; TODO: double check that this is right, and doesn't need to be (map ad/value proposed-trace)
+                ;; TODO: double check that this is right, and doesn't need to be (map ad/shallow-unnest-value proposed-trace)
                 [_ _ guide-score]
                 (mp/infer-and-score :procedure (guide params)
                                     :inputs [observed]
@@ -506,7 +506,7 @@
         score-params
         (fn [params]
           (let [[_ proposed-trace _]
-                (mp/infer-and-score :procedure (guide (map ad/value params))
+                (mp/infer-and-score :procedure (guide (map ad/shallow-unnest-value params))
                                     :inputs [observed])
 
                 [_ _ guide-score]
@@ -520,7 +520,7 @@
 
             ;; Is this right? Seems like there's no reason to use score
             ;; for the `q` here: we know its derivative exactly!
-            (ad/* (- (ad/value model-score) (ad/value guide-score)) guide-score)))
+            (ad/* (- (ad/shallow-unnest-value model-score) (ad/shallow-unnest-value guide-score)) guide-score)))
 
         param-gradient
         ((ad/gradient score-params) current-params)

--- a/src/metaprob/inference.cljc
+++ b/src/metaprob/inference.cljc
@@ -197,8 +197,8 @@
 
           [_ _ forward-proposal-score]            ;; Estimate log q(t' <- t)
           (mp/infer-and-score :procedure proposal
-                               :inputs [current-trace]
-                               :observation-trace all-proposer-choices)
+                              :inputs [current-trace]
+                              :observation-trace all-proposer-choices)
 
           [_ _ backward-proposal-score]          ;; Estimate log q(t <- t')
           (mp/infer-and-score :procedure proposal

--- a/src/metaprob/inference.cljc
+++ b/src/metaprob/inference.cljc
@@ -38,8 +38,8 @@
                                                         :observation-trace observation-trace
                                                         :inputs inputs)]
                        [(* (mp/exp s)
-                           (if f (f t) v)
-                           s)])))
+                           (if f (f t) v))
+                        s])))
         normalizer (mp/exp (dist/logsumexp (map second particles)))]
 
     (/ (reduce + (map first particles)) normalizer)))
@@ -199,8 +199,8 @@
 
           [_ _ backward-proposal-score]          ;; Estimate log q(t <- t')
           (mp/infer-and-score :procedure proposal
-                               :inputs [proposed-trace]
-                               :observation-trace proposed-trace)
+                              :inputs [proposed-trace]
+                              :observation-trace current-trace)
 
           log-acceptance-ratio                  ;; Compute estimate of log [p(t')q(t <- t') / p(t)q(t' <- t)]
           (- (+ new-trace-score backward-proposal-score)

--- a/src/metaprob/prelude.cljc
+++ b/src/metaprob/prelude.cljc
@@ -3,19 +3,20 @@
   (:refer-clojure :exclude [map reduce apply replicate])
   (:require #?(:clj [clojure.java.io :as io])
             [clojure.set :as set]
+            [metaprob.autodiff :as ad]
             [metaprob.trace :as trace]
             [metaprob.generative-functions :refer [gen make-generative-function make-constrained-generator]])
   #?(:clj (:import [java.util Random])))
 
 
 ;; Useful math
-(defn exp [x] (Math/exp x))
-(defn expt [x y] (Math/pow x y))
-(defn sqrt [x] (Math/sqrt x))
-(defn log [x] (Math/log x))
-(defn cos [x] (Math/cos x))
-(defn sin [x] (Math/sin x))
-(defn log1p [x] (Math/log1p x))
+(def exp ad/exp)
+(def expt ad/**)
+(def sqrt ad/sqrt)
+(def log ad/log)
+(def cos ad/cos)
+(def sin ad/sin)
+(def log1p ad/log1p)
 (defn floor [x] (Math/floor x))
 (defn round [x] (Math/round x))
 (def negative-infinity #?(:clj Double/NEGATIVE_INFINITY

--- a/src/metaprob/prelude.cljc
+++ b/src/metaprob/prelude.cljc
@@ -43,8 +43,8 @@
 
 ;; Eager, generative-function versions of common list functions
 (def map
-  (gen [f l]
-    (doall (map-indexed (fn [i x] (at i f x)) l))))
+  (gen [f coll1 & colls]
+    (doall (apply clojure.core/map (fn [i & xs] (apply-at i f xs)) (range (count coll1)) coll1 colls))))
 
 (def replicate
   (gen [n f]

--- a/test/metaprob/autodiff_test.cljc
+++ b/test/metaprob/autodiff_test.cljc
@@ -52,10 +52,9 @@
           xs (repeat n 0.6)
           epsilons (repeat n 1e-4)
           atols (repeat n 1e-5)]
-      (doall (map #(apply compare-single %)
-                  (map vector
-                       (map var-get f-vars)
-                       (map (comp :name meta) f-vars)
-                       xs
-                       epsilons
-                       atols))))))
+      (doall (map compare-single
+                  (map var-get f-vars)
+                  (map (comp :name meta) f-vars)
+                  xs
+                  epsilons
+                  atols)))))

--- a/test/metaprob/autodiff_test.cljc
+++ b/test/metaprob/autodiff_test.cljc
@@ -1,9 +1,19 @@
 (ns metaprob.autodiff-test
   (:refer-clojure :exclude [apply map replicate])
   (:require [clojure.test :refer [deftest is testing]]
-            [metaprob.autodiff :as autodiff :refer [diff lift-real->real]]
+            [metaprob.autodiff :as autodiff :refer [diff lift-real->real recursive-unnest-value]]
             [metaprob.prelude :as prelude :refer [apply map replicate]]
             [metaprob.distributions :as dist]))
+
+
+(defn absdiff [x y]
+  (Math/abs (- x y)))
+
+(defn finite-difference [f x eps]
+  (/ (- (f (+ x eps))
+        (f (- x eps)))
+     (* 2.0 eps)))
+
 
 (deftest deriv-of-identity
   (testing "derivative of the identity function"
@@ -11,3 +21,35 @@
                                     (fn [x] 1)))
              7.0)
             1.0))))
+
+(deftest compare-to-finite-differences
+  (testing "compare autodiff to finite-differences approximation"
+    (let [f-vars [
+                  #'autodiff/tanh
+                  #'autodiff/sqrt
+                  #'autodiff/exp
+                  #'autodiff/log
+                  #'autodiff/log1p
+                  #'autodiff/sin
+                  #'autodiff/cos
+                  #'autodiff/tan
+                  #'autodiff/asin
+                  #'autodiff/acos
+                  #'autodiff/atan
+                  #'autodiff/sinh
+                  #'autodiff/cosh
+                  #'autodiff/tanh
+                  ]
+          n (count f-vars)
+          xs (repeat n 0.6)
+          epsilons (repeat n 1e-4)
+          atols (repeat n 1e-5)]
+      (doseq [f (map var-get f-vars)
+              f-name (map (comp :name meta) f-vars)
+              x xs
+              epsilon epsilons
+              atol atols]
+        (is (< (absdiff ((diff f) x)
+                        (finite-difference f x epsilon))
+               atol)
+            (str "Autodiff disagrees with finite differences for " f-name))))))

--- a/test/metaprob/autodiff_test.cljc
+++ b/test/metaprob/autodiff_test.cljc
@@ -1,0 +1,13 @@
+(ns metaprob.autodiff-test
+  (:refer-clojure :exclude [apply map replicate])
+  (:require [clojure.test :refer [deftest is testing]]
+            [metaprob.autodiff :as autodiff :refer [diff lift-real->real]]
+            [metaprob.prelude :as prelude :refer [apply map replicate]]
+            [metaprob.distributions :as dist]))
+
+(deftest deriv-of-identity
+  (testing "derivative of the identity function"
+    (is (== ((diff (lift-real->real (fn [x] x)
+                                    (fn [x] 1)))
+             7.0)
+            1.0))))


### PR DESCRIPTION
This PR adds preliminary support for forward-mode automatic differentiation to Metaprob.

The AD implementation is based closely off https://github.com/qobi/R6RS-AD/blob/master/AD.ss, and so is also similar to this Clojure AD library, which was based on R6RS-AD too: https://github.com/log0ymxm/clj-auto-diff

To be differentiable by AD, a function needs to consume numerical values only through the AD versions of primitives, including `+`, `-`, `*`, `/`, `number?`, `<`, `>`, `==`, `log`, `exp`, etc., all of which are exposed in the `Metaprob.autodiff` namespace. Distributions now perform their calculations using these primitives, as does `infer-and-score`'s score computation.

If a function `f` of one argument uses these primitives to consume numeric types, then we can call `(metaprob.autodiff/diff f)` to get a version that computes derivatives of `f` with respect to its argument. For a function `f` that accepts a vector of real parameters as its only argument,  `(metaprob.autodiff/gradient f)` returns a vector of partial derivatives with respect to each (the gradient). Note that in this naive implementation, this requires running `f` once for each element of the vector.

AD enables implementations of four new algorithms in `metaprob.inference`:

1. MAP optimization, via `metaprob.inference/map-optimize-step`. Given a generative function, a list of addresses, and a step size, produce a Trace -> Trace function that takes a gradient step on the values of those addresses to increase the probability of the trace.

2. Training via amortized inference, via `train-amortized-inference-program`.

Arguments:
`model` -- the model (a generative function) to do inference in.
`observation-addresses` -- the addresses at which we expect to observe data.
`guide` -- a Clojure function that accepts a vector of real-valued parameters, and returns a "predicter" _generative function_. The predicter accepts as its argument an _observation trace_ of the model, and makes stochastic predictions by tracing to the model addresses at which it is doing inference.
`current-params` -- a vector of reals representing the current parameters of the inference program
`batch-size` -- how many samples from the model to train on at once for this iteration
`step-size` -- multiplier of the gradient used in SGD

Returns: `new-params`, updated parameter values after one step of training

Behavior: simulate `batch-size` samples from the model, and take a single gradient step on the params to maximize the probability, under the predicter, of those samples. Minimizes KL(p||q), so is good for training proposal distributions.

3. ELBO optimization with the reparametrization trick, via `reparam-variational-inference`

Arguments: same as in (2) (except batch size is always 1). 
Behavior: take a single gradient step on the params to minimize the expected KL(q(x; obs)||p(x|obs)) (where the expectation is taken with respect to `observations ~ p`). In the case where there are no observation addresses, there is no expectation, and this just minimizes `KL(q(x)||p(x))`. Assumes that tall random choices that depend on the parameters of the guide are reparameterizable (currently, only the normal distribution).

4. ELBO optimization with the score function estimator, via `score-func-variational-inference`
Arguments: same as in (3)
Behavior: same as in (3), except no assumptions are made about reparameterization, and instead the (higher-variance) score function estimator is used to estimate gradients.

There is also a new sequence of demos in the `metaprob.examples.variational-on-gaussians` namespace.
