### PR TITLE
Simplify the sampling logic for `categorical`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,11 @@ RUN curl -O https://download.clojure.org/install/linux-install-${CLOJURE_VERSION
       && chmod +x linux-install-${CLOJURE_VERSION}.sh \
       && ./linux-install-${CLOJURE_VERSION}.sh
 
+# Work around a bug in the Ubuntu package `ca-certificates-java`
+# (https://stackoverflow.com/a/33440168)
+RUN dpkg --purge --force-depends ca-certificates-java \
+      && apt-get install ca-certificates-java
+
 # Install Planck so we can run our tests in self-hosted mode.
 
 RUN apt-get update \

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
         incanter/incanter-core {:mvn/version "1.9.3"}
         kixi/stats {:mvn/version "0.4.0"}}
 
- :aliases {:examples {:jvm-opts ["-Xss50M"]
+ :aliases {:examples {:jvm-opts ["-Xss50M" "-Dhttps.protocols=TLSv1.2"]
                       :main-opts ["-m" "metaprob.examples.main"]}
            :test {:extra-paths ["test"]
                   :extra-deps {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
@@ -11,7 +11,7 @@
                   ;; Default stack size is 1MB or less, increase to 50. For more
                   ;; information on `java` options:
                   ;; https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html
-                  :jvm-opts ["-Xss50M"]
+                  :jvm-opts ["-Xss50M" "-Dhttps.protocols=TLSv1.2"]
                   :main-opts ["-m" "cognitect.test-runner"]}
 
            :cljs {:extra-deps {org.clojure/clojurescript {:mvn/version "1.10.339"}}}

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,8 @@
 (defproject metaprob "0.1.0-SNAPSHOT"
-  :jvm-opts ["-Xss50M"] ; See `deps.edn` for an explanation of this setting
+  :jvm-opts [
+             "-Xss50M" ; See `deps.edn` for an explanation of this setting
+             "-Dhttps.protocols=TLSv1.2" ; See https://stackoverflow.com/a/50956622
+             ]
   :source-paths ["tutorial/src"]
   :resource-paths ["tutorial/resources"]
   :dependencies [[org.clojure/data.json "0.2.6"]

--- a/src/metaprob/distributions.cljc
+++ b/src/metaprob/distributions.cljc
@@ -38,8 +38,10 @@
        (nth (keys probs) (categorical (normalize-numbers (vals probs)))) ;; TODO: normalization not needed here?
        (let [total (clojure.core/reduce + probs)
              r (* (mp/sample-uniform) total)]
-         (loop [i 0, sum 0]
-           (if (< r (+ (nth probs i) sum)) i (recur (inc i) (+ (nth probs i) sum)))))))
+         (->> probs
+              (reductions +)
+              (take-while #(< % r ))
+              count))))
    (fn [i [probs]]
      (if (map? probs)
        (if (not (contains? probs i)) mp/negative-infinity (- (mp/log (get probs i)) (mp/log (clojure.core/reduce + (vals probs)))))

--- a/src/metaprob/distributions.cljc
+++ b/src/metaprob/distributions.cljc
@@ -40,7 +40,7 @@
              r (* (mp/sample-uniform) total)]
          (->> probs
               (reductions +)
-              (take-while #(< % r ))
+              (take-while #(< % r))
               count))))
    (fn [i [probs]]
      (if (map? probs)


### PR DESCRIPTION
# Summary

Changes the sampling logic for `categorical` to use sequence primitives rather than a loop with explicit indices.

Also fixes https://github.com/probcomp/metaprob/issues/160 as it was in the way of merging this PR :slightly_smiling_face: 

# Tested

Unit tests still pass.

Performance is about the same, perhaps slightly faster (see https://github.com/probcomp/metaprob/pull/159#issuecomment-518892534).