### PR TITLE
Replace incanter with Apache Commons Math

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
-{:deps {org.clojure/clojure {:mvn/version "1.9.0"}
-        org.clojure/tools.cli {:mvn/version "0.4.1"}
-        incanter/incanter-core {:mvn/version "1.9.3"}
-        kixi/stats {:mvn/version "0.4.0"}}
+{:deps {kixi/stats {:mvn/version "0.4.0"}
+        org.apache.commons/commons-math3 {:mvn/version "3.6.1"}
+        org.clojure/clojure {:mvn/version "1.9.0"}
+        org.clojure/tools.cli {:mvn/version "0.4.1"}}
 
  :aliases {:examples {:jvm-opts ["-Xss50M" "-Dhttps.protocols=TLSv1.2"]
                       :main-opts ["-m" "metaprob.examples.main"]}

--- a/src/metaprob/distributions.cljc
+++ b/src/metaprob/distributions.cljc
@@ -1,7 +1,7 @@
 (ns metaprob.distributions
   (:refer-clojure :exclude [apply map replicate reduce])
-  (:require [metaprob.prelude :as mp :refer [map make-primitive]]
-            #?(:clj [incanter.distributions :as distributions])))
+  (:require [metaprob.prelude :as mp :refer [map make-primitive]])
+  #?(:clj (:import [org.apache.commons.math3.distribution BetaDistribution GammaDistribution])))
 
 (def exactly
   (make-primitive
@@ -95,19 +95,15 @@
 #?(:clj (def gamma
           (make-primitive
            (fn [shape scale]
-             (distributions/draw
-              (distributions/gamma-distribution shape scale)))
+             (.sample (GammaDistribution. shape scale)))
            (fn [x [shape scale]]
-             (mp/log (distributions/pdf
-                   (distributions/gamma-distribution shape scale)
-                   x))))))
+             (.logDensity (GammaDistribution. shape scale)
+                          x)))))
 
 #?(:clj (def beta
           (make-primitive
            (fn [alpha beta]
-             (distributions/draw
-              (distributions/beta-distribution alpha beta)))
+             (.sample (BetaDistribution. alpha beta)))
            (fn [x [alpha beta]]
-             (mp/log (distributions/pdf
-                   (distributions/beta-distribution alpha beta)
-                   x))))))
+             (.logDensity (BetaDistribution. alpha beta)
+                          x)))))


### PR DESCRIPTION
## Overview

Replaces calls to incanter with calls to Apache Commons Math. incanter is only used for gamma and beta.

## Motivation

incanter is no longer maintained. This has resulted in downstream issues such as #InferenceQL/inferenceql.query#16.
